### PR TITLE
CORS env in docker-compose scripts updated.

### DIFF
--- a/docker-compose.run.yml
+++ b/docker-compose.run.yml
@@ -9,7 +9,7 @@ services:
       - ONTOP_ONTOLOGY_FILE=/opt/ontop/input/odh.ttl
       - ONTOP_MAPPING_FILE=/opt/ontop/input/odh.obda
       - ONTOP_PROPERTIES_FILE=/opt/ontop/input/odh.docker.properties
-      - ONTOP_CORS_ALLOWED_ORIGINS='*'
+      - ONTOP_CORS_ALLOWED_ORIGINS=*
     volumes:
       - ./vkg:/opt/ontop/input
       - ./jdbc:/opt/ontop/jdbc

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - ONTOP_ONTOLOGY_FILE=/opt/ontop/input/odh.ttl
       - ONTOP_MAPPING_FILE=/opt/ontop/input/odh.obda
       - ONTOP_PROPERTIES_FILE=/opt/ontop/input/odh.docker.properties
-      - ONTOP_CORS_ALLOWED_ORIGINS='*'
+      - ONTOP_CORS_ALLOWED_ORIGINS=*
     volumes:
       - ./vkg:/opt/ontop/input
       - ./jdbc:/opt/ontop/jdbc


### PR DESCRIPTION
The wildcard for the CORS allowed origins is ignored when it is surrounded by single quotes inside an environment variable.

This issue was preventing the YASGUI javascript client to be used on Chrome (but was working on Firefox).