### PR TITLE
Mapping enrichment and advanced query logging

### DIFF
--- a/vkg/odh.docker.properties
+++ b/vkg/odh.docker.properties
@@ -16,3 +16,5 @@ ontop.queryLogging.includeSparqlQuery=true
 ontop.queryLogging.includeReformulatedQuery=true
 ontop.queryLogging.includeClassesAndProperties=true
 ontop.queryLogging.includeTables=true
+ontop.queryLogging.includeHttpHeader.referer=true
+ontop.queryLogging.extractQueryTemplate=true

--- a/vkg/odh.obda
+++ b/vkg/odh.obda
@@ -1,5 +1,6 @@
 [PrefixDeclaration]
 :		http://noi.example.org/ontology/odh#
+data:   http://noi.example.org/data/
 dc:		http://purl.org/dc/terms/
 geo:		http://www.opengis.net/ont/geosparql#
 owl:		http://www.w3.org/2002/07/owl#
@@ -12,23 +13,23 @@ schema:		http://schema.org/
 
 [MappingDeclaration] @collection [[
 mappingId	Campground
-target		:data/accommodation/{Id} a schema:Campground . 
+target		data:accommodation/{Id} a schema:Campground . 
 source		SELECT "Id"
 			FROM "v_accommodationsopen"
 			WHERE "AccoTypeId" = 'Camping'
 
 mappingId	LodgingBusiness
-target		:data/accommodation/{id} a schema:LodgingBusiness ; geo:asWKT "POINT ({longitude} {latitude})"^^geo:wktLiteral ; schema:email <{email}> ; schema:name {de_name}@de , {it_name}@it , {en_name}@en ; schema:telephone {de_phone} ; schema:faxNumber {de_fax} . 
+target		data:accommodation/{id} a schema:LodgingBusiness ; geo:asWKT "POINT ({longitude} {latitude})"^^geo:wktLiteral ; schema:email <{email}> ; schema:name {de_name}@de , {it_name}@it , {en_name}@en ; schema:telephone {de_phone} ; schema:faxNumber {de_fax} . 
 source		SELECT "Id" AS id, "Latitude" AS latitude, "Longitude" AS longitude, CONCAT('mailto:', "AccoDetail-de-Email") AS email, "AccoDetail-de-Name" AS de_name,  "AccoDetail-en-Name" AS en_name, "AccoDetail-it-Name" AS it_name, "AccoDetail-de-Phone" AS de_phone, "AccoDetail-de-Mobile"  AS mobile, "AccoDetail-de-Fax" AS  de_fax
 			FROM "v_accommodationsopen"
 
 mappingId	Lodging business - geo
-target		:data/geo/accommodation/{id} a schema:GeoCoordinates ; schema:latitude {latitude} ; schema:elevation {altitude} ; schema:longitude {longitude} . :data/accommodation/{id} schema:geo :data/geo/accommodation/{id} . 
+target		data:geo/accommodation/{id} a schema:GeoCoordinates ; schema:latitude {latitude} ; schema:elevation {altitude} ; schema:longitude {longitude} . data:accommodation/{id} schema:geo data:geo/accommodation/{id} . 
 source		SELECT "Id" AS id, "Latitude" AS latitude, "Longitude" AS longitude, "Altitude" AS altitude
 			FROM "v_accommodationsopen"
 
 mappingId	LodgingBusiness - address
-target		:data/address/accommodation/{id} a schema:PostalAddress ; schema:streetAddress {de_street}@de , {it_street}@it , {en_street}@en ; schema:postalCode {de_zip} ; schema:addressLocality {de_city}@de , {it_city}@it , {en_city}@en . :data/accommodation/{id} schema:address :data/address/accommodation/{id} . 
+target		data:address/accommodation/{id} a schema:PostalAddress ; schema:streetAddress {de_street}@de , {it_street}@it , {en_street}@en ; schema:postalCode {de_zip} ; schema:addressLocality {de_city}@de , {it_city}@it , {en_city}@en . data:accommodation/{id} schema:address data:address/accommodation/{id} . 
 source		SELECT "Id" AS id,
 			"AccoDetail-de-City" AS de_city, "AccoDetail-de-Zip" AS de_zip, "AccoDetail-de-Street" AS de_street,
 			"AccoDetail-it-City" AS it_city, "AccoDetail-it-Street" AS it_street,
@@ -36,237 +37,237 @@ source		SELECT "Id" AS id,
 			FROM "v_accommodationsopen"
 
 mappingId	PensionHotel
-target		:data/accommodation/{id} a schema:Hotel . 
+target		data:accommodation/{id} a schema:Hotel . 
 source		SELECT "Id" AS id
 			FROM "v_accommodationsopen"
 			WHERE "AccoTypeId" = 'HotelPension'
 
 mappingId	Hostel
-target		:data/accommodation/{id} a schema:Hostel . 
+target		data:accommodation/{id} a schema:Hostel . 
 source		SELECT "Id" AS id
 			FROM "v_accommodationsopen"
 			WHERE "AccoTypeId" = 'Youth'
 
 mappingId	BedAndBreakfast
-target		:data/accommodation/{id} a schema:BedAndBreakfast . 
+target		data:accommodation/{id} a schema:BedAndBreakfast . 
 source		SELECT "Id" AS id
 			FROM "v_accommodationsopen"
 			WHERE "AccoTypeId" = 'BedBreakfast'
 
 mappingId	POI
-target		:data/poi/{Id} a schema:Place ; rdfs:label {Shortname}^^xsd:string ; schema:name {Shortname}^^xsd:string ; geo:asWKT "POINT ({GpsPoints-position-Longitude} {GpsPoints-position-Latitude})"^^geo:wktLiteral . 
+target		data:poi/{Id} a schema:Place ; rdfs:label {Shortname}^^xsd:string ; schema:name {Shortname}^^xsd:string ; geo:asWKT "POINT ({GpsPoints-position-Longitude} {GpsPoints-position-Latitude})"^^geo:wktLiteral . 
 source		SELECT "Id", "Shortname", "GpsPoints-position-Latitude", "GpsPoints-position-Longitude" FROM v_poisopen
 
 mappingId	Area
-target		:data/area/{Id} a schema:AdministrativeArea ; rdfs:label {Shortname}^^xsd:string ; schema:name {Shortname}^^xsd:string . 
+target		data:area/{Id} a schema:AdministrativeArea ; rdfs:label {Shortname}^^xsd:string ; schema:name {Shortname}^^xsd:string . 
 source		SELECT "Id", "Shortname" FROM v_areas
 
 mappingId	POI_Area
-target		:data/poi/{Id} schema:isPartOf :data/area/{data} . 
+target		data:poi/{Id} schema:isPartOf data:area/{data} . 
 source		SELECT "Id", "data" FROM "v_poisopen_AreaId";
 
 mappingId	POI-geo
-target		:data/poi/{Id} schema:geo :data/geo/poi/{Id} . :data/geo/poi/{Id} a schema:GeoCoordinates ; schema:longitude {GpsPoints-position-Longitude} ; schema:latitude {GpsPoints-position-Latitude} ; schema:elevation {GpsPoints-position-Altitude} . 
+target		data:poi/{Id} schema:geo data:geo/poi/{Id} . data:geo/poi/{Id} a schema:GeoCoordinates ; schema:longitude {GpsPoints-position-Longitude} ; schema:latitude {GpsPoints-position-Latitude} ; schema:elevation {GpsPoints-position-Altitude} . 
 source		SELECT "Id", "Shortname", "GpsPoints-position-Latitude", "GpsPoints-position-Longitude", "GpsPoints-position-Altitude" FROM v_poisopen
 
 mappingId	Accommodation
-target		:data/room/{Id} a schema:Accommodation ; schema:containedInPlace :data/accommodation/{A0RID} ; schema:name {AccoRoomDetail-it-Name}@it , {AccoRoomDetail-en-Name}@en , {AccoRoomDetail-de-Name}@de ; :numberOfUnits {RoomQuantity} ; schema:occupancy :data/occupancy/room/{Id} . 
+target		data:room/{Id} a schema:Accommodation ; schema:containedInPlace data:accommodation/{A0RID} ; schema:name {AccoRoomDetail-it-Name}@it , {AccoRoomDetail-en-Name}@en , {AccoRoomDetail-de-Name}@de ; :numberOfUnits {RoomQuantity} ; schema:occupancy data:occupancy/room/{Id} . 
 source		SELECT "Id", "A0RID", "AccoRoomDetail-en-Name", "AccoRoomDetail-de-Name", "AccoRoomDetail-it-Name", "RoomQuantity" FROM v_accommodationroomsopen
 
 mappingId	Room
-target		:data/room/{Id} a schema:Room . 
+target		data:room/{Id} a schema:Room . 
 source		SELECT "Id" FROM v_accommodationroomsopen
 			WHERE "Roomtype" = 'room'
 
 mappingId	Apartment
-target		:data/room/{Id} a schema:Apartment . 
+target		data:room/{Id} a schema:Apartment . 
 source		SELECT "Id" FROM v_accommodationroomsopen
 			WHERE "Roomtype" = 'apartment'
 
 mappingId	Camping pitch
-target		:data/room/{Id} a schema:CampingPitch . 
+target		data:room/{Id} a schema:CampingPitch . 
 source		SELECT "Id" FROM v_accommodationroomsopen
 			WHERE "Roomtype" = 'pitch' OR "Roomtype" = 'campsite'
 
 mappingId	Room occupancy
-target		:data/occupancy/room/{Id} a schema:QuantitativeValue ; schema:minValue {Roommin} ; schema:maxValue {Roommax} ; schema:unitCode "C62" . 
+target		data:occupancy/room/{Id} a schema:QuantitativeValue ; schema:minValue {Roommin} ; schema:maxValue {Roommax} ; schema:unitCode "C62" . 
 source		SELECT "Id", "Roommin", "Roommax"
 			FROM v_accommodationroomsopen
 
 mappingId	Event EURAC NOI
-target		:data/event/euracnoi/{Id} a schema:Event ; schema:startDate {StartDate}^^xsd:dateTime ; schema:endDate {EndDate}^^xsd:dateTime ; schema:description {EventDescriptionIT}@it , {EventDescriptionDE}@de , {EventDescriptionEN}@en ; schema:location :data/location/euracnoi/{EventLocation}/{AnchorVenue} ; schema:organizer :data/organization/event/euracnoi/{Id} , :data/contact/event/euracnoi/{Id} . 
+target		data:event/euracnoi/{Id} a schema:Event ; schema:startDate {StartDate}^^xsd:dateTime ; schema:endDate {EndDate}^^xsd:dateTime ; schema:description {EventDescriptionIT}@it , {EventDescriptionDE}@de , {EventDescriptionEN}@en ; schema:location data:location/euracnoi/{EventLocation}/{AnchorVenue} ; schema:organizer data:organization/event/euracnoi/{Id} , data:contact/event/euracnoi/{Id} . 
 source		SELECT "Id", "StartDate", "EndDate", "EventDescriptionIT", "EventDescriptionEN", "AnchorVenue", "EventLocation", "EventDescriptionDE"
 			FROM v_eventeuracnoi
 
 mappingId	Event Organization
-target		:data/organization/event/euracnoi/{Id} a schema:Organization ; schema:name {CompanyName} . 
+target		data:organization/event/euracnoi/{Id} a schema:Organization ; schema:name {CompanyName} . 
 source		select "Id", "CompanyName"
 			from v_eventeuracnoi
 
 mappingId	Event Location
-target		:data/location/euracnoi/{EventLocation}/{AnchorVenue} a schema:MeetingRoom ; schema:name {AnchorVenue} ; schema:containedInPlace :data/place/euracnoi/{EventLocation} . 
+target		data:location/euracnoi/{EventLocation}/{AnchorVenue} a schema:MeetingRoom ; schema:name {AnchorVenue} ; schema:containedInPlace data:place/euracnoi/{EventLocation} . 
 source		select "Id", "AnchorVenue", "EventLocation"
 			from v_eventeuracnoi
 
 mappingId	Event Contact Person
-target		:data/contact/event/euracnoi/{Id} a schema:Person ; schema:familyName {ContactLastName} ; schema:givenName {ContactFirstName} ; schema:email <{email}> ; schema:telephone {ContactPhone} ; schema:worksFor :data/organization/event/euracnoi/{Id} . 
+target		data:contact/event/euracnoi/{Id} a schema:Person ; schema:familyName {ContactLastName} ; schema:givenName {ContactFirstName} ; schema:email <{email}> ; schema:telephone {ContactPhone} ; schema:worksFor data:organization/event/euracnoi/{Id} . 
 source		select "Id", "ContactFirstName", "ContactLastName", concat('mailto:',"ContactEmail") as email, "ContactPhone"
 			from v_eventeuracnoi
 
 mappingId	Event Organization - company address
-target		:data/address/organization/event/euracnoi/{Id} a schema:PostalAddress ; schema:streetAddress {CompanyAddressLine1} ; schema:postalCode {CompanyPostalCode} ; schema:addressLocality {CompanyCity} ; schema:addressCountry {CompanyCountry} . :data/organization/event/euracnoi/{Id} schema:address :data/address/organization/event/euracnoi/{Id} . 
+target		data:address/organization/event/euracnoi/{Id} a schema:PostalAddress ; schema:streetAddress {CompanyAddressLine1} ; schema:postalCode {CompanyPostalCode} ; schema:addressLocality {CompanyCity} ; schema:addressCountry {CompanyCountry} . data:organization/event/euracnoi/{Id} schema:address data:address/organization/event/euracnoi/{Id} . 
 source		select "Id", "CompanyAddressLine1", "CompanyCity", "CompanyCountry", "CompanyPostalCode"
 			from v_eventeuracnoi
 
 mappingId	Caravan pitch
-target		:data/room/{Id} a :CaravanPitch . 
+target		data:room/{Id} a :CaravanPitch . 
 source		SELECT "Id" FROM v_accommodationroomsopen
 			WHERE "Roomtype" = 'caravan'
 
 mappingId	SkiResort
-target		:data/skiResort/{Id} a schema:SkiResort ; rdfs:label {Detail-en-Header}^^xsd:string ; schema:name {Detail-en-Header}^^xsd:string ; geo:asWKT "POINT ({Longitude} {Latitude})"^^geo:wktLiteral ; schema:image <{SkiAreaMapURL}> ; schema:isPartOf :data/skiRegion/{SkiRegionId} ; schema:geo :data/geo/skiResort/{Id} . 
+target		data:skiResort/{Id} a schema:SkiResort ; rdfs:label {Detail-en-Header}^^xsd:string ; schema:name {Detail-en-Header}^^xsd:string ; geo:asWKT "POINT ({Longitude} {Latitude})"^^geo:wktLiteral ; schema:image <{SkiAreaMapURL}> ; schema:isPartOf data:skiRegion/{SkiRegionId} ; schema:geo data:geo/skiResort/{Id} . 
 source		SELECT "Id", "Shortname", "Detail-en-Header", "Longitude", "Latitude", "AltitudeTo", "SkiAreaMapURL", "SkiRegionId" FROM v_skiareasopen
 
 mappingId	SkiRegion
-target		:data/skiRegion/{Id} a :SkiRegion ; rdfs:label {Shortname}^^xsd:string ; schema:name {Shortname}^^xsd:string ; geo:asWKT "POINT ({Longitude} {Latitude})"^^geo:wktLiteral ; schema:elevation {Altitude}^^xsd:decimal . 
+target		data:skiRegion/{Id} a :SkiRegion ; rdfs:label {Shortname}^^xsd:string ; schema:name {Shortname}^^xsd:string ; geo:asWKT "POINT ({Longitude} {Latitude})"^^geo:wktLiteral ; schema:elevation {Altitude}^^xsd:decimal . 
 source		SELECT "Id", "Shortname", "Longitude", "Latitude", "Altitude" FROM v_skiregionsopen
 
 mappingId	SkiResort_Area
-target		:data/skiResort/{Id} schema:isPartOf :data/area/{data} . 
+target		data:skiResort/{Id} schema:isPartOf data:area/{data} . 
 source		SELECT "Id", "data" FROM "v_skiareasopen_AreaId"
 
 mappingId	MedicalOrganization
-target		:data/poi/{Id} a schema:MedicalOrganization . 
+target		data:poi/{Id} a schema:MedicalOrganization . 
 source		SELECT * FROM v_poisopen WHERE "Type" = 'Ärzte, Apotheken'
 
 mappingId	Theater
-target		:data/poi/{Id} a schema:PerformingArtsTheater . 
+target		data:poi/{Id} a schema:PerformingArtsTheater . 
 source		SELECT * FROM v_poisopen WHERE "SubType" = 'Theater'
 
 mappingId	Activity
-target		:data/Activity/{SubType} a :Activity ; rdfs:label {SubType}^^xsd:string ; schema:name {SubType}^^xsd:string ; :activityType {Type}^^xsd:string . 
+target		data:Activity/{SubType} a :Activity ; rdfs:label {SubType}^^xsd:string ; schema:name {SubType}^^xsd:string ; :activityType {Type}^^xsd:string . 
 source		SELECT "Type", "SubType"
 			FROM v_smgpoisopen
 
 mappingId	Wine
-target		:data/wine/{Id} a :Wine ; rdfs:label {Shortname} ; schema:name {Shortname} ; :wineVintageYear {Vintage} ; :wineAwardYear {Awardyear} . 
+target		data:wine/{Id} a :Wine ; rdfs:label {Shortname} ; schema:name {Shortname} ; :wineVintageYear {Vintage} ; :wineAwardYear {Awardyear} . 
 source		SELECT * FROM v_wines
 
 mappingId	WineAward
-target		:data/wine/{Id} a :Wine ; :receivesWineAward {data}^^xsd:string . 
+target		data:wine/{Id} a :Wine ; :receivesWineAward {data}^^xsd:string . 
 source		SELECT * FROM "v_wines_Awards"
 
 mappingId	Ski resort - geo
-target		:data/geo/skiResort/{Id} a schema:GeoCoordinates ; schema:latitude {Latitude} ; schema:elevation {AltitudeTo} ; schema:longitude {Longitude} . 
+target		data:geo/skiResort/{Id} a schema:GeoCoordinates ; schema:latitude {Latitude} ; schema:elevation {AltitudeTo} ; schema:longitude {Longitude} . 
 source		SELECT "Id",  "Longitude", "Latitude", "AltitudeTo" FROM v_skiareasopen
 
 mappingId	Place EURAC NOI
-target		:data/place/euracnoi/{EventLocation} a schema:Place . 
+target		data:place/euracnoi/{EventLocation} a schema:Place . 
 source		select "EventLocation"
 			from v_eventeuracnoi
 
 mappingId	Food establishments
-target		:data/gastronomy/{Id} a schema:FoodEstablishment ; geo:asWKT "POINT ({Longitude} {Latitude})"^^geo:wktLiteral ; schema:name {Detail-de-Title}@de , {Detail-it-Title}@it , {Detail-en-Title}@en ; schema:description {Detail-de-BaseText}@de , {Detail-it-BaseText}@it , {Detail-en-BaseText}@en ; schema:geo :data/geo/gastronomy/{Id} ; schema:address :data/address/gastronomy/{Id} ; schema:telephone {ContactInfos-de-Phonenumber} ; schema:hasMenu :data/menu/gastronomy/{Id} . 
+target		data:gastronomy/{Id} a schema:FoodEstablishment ; geo:asWKT "POINT ({Longitude} {Latitude})"^^geo:wktLiteral ; schema:name {Detail-de-Title}@de , {Detail-it-Title}@it , {Detail-en-Title}@en ; schema:description {Detail-de-BaseText}@de , {Detail-it-BaseText}@it , {Detail-en-BaseText}@en ; schema:geo data:geo/gastronomy/{Id} ; schema:address data:address/gastronomy/{Id} ; schema:telephone {ContactInfos-de-Phonenumber} ; schema:hasMenu data:menu/gastronomy/{Id} . 
 source		SELECT * FROM v_gastronomiesopen
 
 mappingId	Food establishments - geo
-target		:data/geo/gastronomy/{Id} a schema:GeoCoordinates ; schema:latitude {Latitude} ; schema:elevation {Altitude} ; schema:longitude {Longitude} . 
+target		data:geo/gastronomy/{Id} a schema:GeoCoordinates ; schema:latitude {Latitude} ; schema:elevation {Altitude} ; schema:longitude {Longitude} . 
 source		SELECT * FROM v_gastronomiesopen
 
 mappingId	Food establishments - address
-target		:data/address/gastronomy/{Id} a schema:PostalAddress ; schema:streetAddress {ContactInfos-de-Address}@de , {ContactInfos-it-Address}@it , {ContactInfos-en-Address}@en ; schema:postalCode {ContactInfos-de-ZipCode} ; schema:addressLocality {ContactInfos-de-City}@de , {ContactInfos-it-City}@it , {ContactInfos-en-City}@en . 
+target		data:address/gastronomy/{Id} a schema:PostalAddress ; schema:streetAddress {ContactInfos-de-Address}@de , {ContactInfos-it-Address}@it , {ContactInfos-en-Address}@en ; schema:postalCode {ContactInfos-de-ZipCode} ; schema:addressLocality {ContactInfos-de-City}@de , {ContactInfos-it-City}@it , {ContactInfos-en-City}@en . 
 source		SELECT * FROM v_gastronomiesopen
 
 mappingId	Restaurants
-target		:data/gastronomy/{gastronomiesopen_Id} a schema:Restaurant . 
+target		data:gastronomy/{gastronomiesopen_Id} a schema:Restaurant . 
 source		SELECT *
 			FROM "v_gastronomiesopen_CategoryCodes"
 			WHERE "Shortname" = 'Restaurant' OR "Shortname" = 'Gasthof'
 
 mappingId	Bar/pub
-target		:data/gastronomy/{gastronomiesopen_Id} a schema:BarOrPub . 
+target		data:gastronomy/{gastronomiesopen_Id} a schema:BarOrPub . 
 source		SELECT *
 			FROM "v_gastronomiesopen_CategoryCodes"
 			WHERE "Shortname" = 'Bar / Coffee Shop / Bistro' OR "Shortname" = 'Pub / Disco' OR "Shortname" = 'Braugarten'  OR "Shortname" = 'Apres Ski'
 
 mappingId	Fast food
-target		:data/gastronomy/{gastronomiesopen_Id} a schema:FastFoodRestaurant . 
+target		data:gastronomy/{gastronomiesopen_Id} a schema:FastFoodRestaurant . 
 source		SELECT *
 			FROM "v_gastronomiesopen_CategoryCodes"
 			WHERE "Shortname" = 'Schnellimbiss'
 
 mappingId	Winery
-target		:data/gastronomy/{gastronomiesopen_Id} a schema:Winery . 
+target		data:gastronomy/{gastronomiesopen_Id} a schema:Winery . 
 source		SELECT *
 			FROM "v_gastronomiesopen_CategoryCodes"
 			WHERE "Shortname" = 'Vinothek / Weinhaus / Taverne'
 
 mappingId	Ice cream shops
-target		:data/gastronomy/{gastronomiesopen_Id} a schema:IceCreamShop . 
+target		data:gastronomy/{gastronomiesopen_Id} a schema:IceCreamShop . 
 source		SELECT *
 			FROM "v_gastronomiesopen_CategoryCodes"
 			WHERE "Shortname" = 'Eisdiele'
 
 mappingId	Food establishments - URL
-target		:data/gastronomy/{Id} schema:sameAs <{url}> ; schema:url <{url}> . 
+target		data:gastronomy/{Id} schema:sameAs <{url}> ; schema:url <{url}> . 
 source		SELECT "Id",  NULLIF("ContactInfos-de-Url", '') AS url FROM v_gastronomiesopen
 
 mappingId	Pizzeria
-target		:data/gastronomy/{gastronomiesopen_Id} a :Pizzeria . 
+target		data:gastronomy/{gastronomiesopen_Id} a :Pizzeria . 
 source		SELECT *
 			FROM "v_gastronomiesopen_CategoryCodes"
 			WHERE "Shortname" = 'Pizzeria'
 
 mappingId	Mountain restaurant
-target		:data/gastronomy/{gastronomiesopen_Id} a :MountainRestaurant . 
+target		data:gastronomy/{gastronomiesopen_Id} a :MountainRestaurant . 
 source		SELECT *
 			FROM "v_gastronomiesopen_CategoryCodes"
 			WHERE "Shortname" = 'Alm'
 
 mappingId	Skihütte
-target		:data/gastronomy/{gastronomiesopen_Id} a :SkiHütte . 
+target		data:gastronomy/{gastronomiesopen_Id} a :SkiHütte . 
 source		SELECT *
 			FROM "v_gastronomiesopen_CategoryCodes"
 			WHERE "Shortname" = 'Skihütte'
 
 mappingId	Mensa
-target		:data/gastronomy/{gastronomiesopen_Id} a :Canteen . 
+target		data:gastronomy/{gastronomiesopen_Id} a :Canteen . 
 source		SELECT *
 			FROM "v_gastronomiesopen_CategoryCodes"
 			WHERE "Shortname" = 'Mensa'
 
 mappingId	Après ski
-target		:data/gastronomy/{gastronomiesopen_Id} a :AprèsSki . 
+target		data:gastronomy/{gastronomiesopen_Id} a :AprèsSki . 
 source		SELECT *
 			FROM "v_gastronomiesopen_CategoryCodes"
 			WHERE "Shortname" = 'Apres Ski'
 
 mappingId	Jausenstation
-target		:data/gastronomy/{gastronomiesopen_Id} a :Jausenstation . 
+target		data:gastronomy/{gastronomiesopen_Id} a :Jausenstation . 
 source		SELECT *
 			FROM "v_gastronomiesopen_CategoryCodes"
 			WHERE "Shortname" = 'Jausenstation'
 
 mappingId	Beer garden
-target		:data/gastronomy/{gastronomiesopen_Id} a :BeerGarden . 
+target		data:gastronomy/{gastronomiesopen_Id} a :BeerGarden . 
 source		SELECT *
 			FROM "v_gastronomiesopen_CategoryCodes"
 			WHERE "Shortname" = 'Braugarten'
 
 mappingId	Asian cuisine
-target		:data/gastronomy/{Id} schema:servesCuisine "asian"@en , "asiatisch"@de , "asiatica"@it . 
+target		data:gastronomy/{Id} schema:servesCuisine "asian"@en , "asiatisch"@de , "asiatica"@it . 
 source		SELECT "Id", "Detail-it-BaseText", "Detail-de-BaseText"
 			FROM "v_gastronomiesopen"
 			WHERE "Detail-it-BaseText" like '%asiat%' OR "Detail-de-BaseText" like '%asiat%'
 
 mappingId	Mediterranean cuisine
-target		:data/gastronomy/{Id} schema:servesCuisine "mediterranean"@en , "mediterrane"@de , "mediterranea"@it . 
+target		data:gastronomy/{Id} schema:servesCuisine "mediterranean"@en , "mediterrane"@de , "mediterranea"@it . 
 source		SELECT "Id", "Detail-it-BaseText", "Detail-de-BaseText"
 			FROM "v_gastronomiesopen"
 			WHERE "Detail-it-BaseText" like '%mediterra%' OR "Detail-de-BaseText" like '%mediterra%'
 
 mappingId	Apfelstrudel
-target		:data/menu/gastronomy/{Id} schema:hasMenuItem :data/menuitem/apfelstrudel/{Id} . :data/menuitem/apfelstrudel/{Id} schema:name "Apfelstrudel"@de , "strudel di mela"@it , "Apfelstrudel"@en . 
+target		data:menu/gastronomy/{Id} schema:hasMenuItem data:menuitem/apfelstrudel/{Id} . data:menuitem/apfelstrudel/{Id} schema:name "Apfelstrudel"@de , "strudel di mela"@it , "Apfelstrudel"@en . 
 source		SELECT "Id"
 			FROM public.v_gastronomiesopen
 			WHERE "Detail-de-BaseText" ~ 'Apfelstrudel'

--- a/vkg/odh.obda
+++ b/vkg/odh.obda
@@ -1,12 +1,12 @@
 [PrefixDeclaration]
 :		http://noi.example.org/ontology/odh#
-data:   http://noi.example.org/data/
 dc:		http://purl.org/dc/terms/
 geo:		http://www.opengis.net/ont/geosparql#
 owl:		http://www.w3.org/2002/07/owl#
 rdf:		http://www.w3.org/1999/02/22-rdf-syntax-ns#
 xml:		http://www.w3.org/XML/1998/namespace
 xsd:		http://www.w3.org/2001/XMLSchema#
+data:		http://noi.example.org/data/
 obda:		https://w3id.org/obda/vocabulary#
 rdfs:		http://www.w3.org/2000/01/rdf-schema#
 schema:		http://schema.org/
@@ -19,8 +19,8 @@ source		SELECT "Id"
 			WHERE "AccoTypeId" = 'Camping'
 
 mappingId	LodgingBusiness
-target		data:accommodation/{id} a schema:LodgingBusiness ; geo:asWKT "POINT ({longitude} {latitude})"^^geo:wktLiteral ; schema:email <{email}> ; schema:name {de_name}@de , {it_name}@it , {en_name}@en ; schema:telephone {de_phone} ; schema:faxNumber {de_fax} . 
-source		SELECT "Id" AS id, "Latitude" AS latitude, "Longitude" AS longitude, CONCAT('mailto:', "AccoDetail-de-Email") AS email, "AccoDetail-de-Name" AS de_name,  "AccoDetail-en-Name" AS en_name, "AccoDetail-it-Name" AS it_name, "AccoDetail-de-Phone" AS de_phone, "AccoDetail-de-Mobile"  AS mobile, "AccoDetail-de-Fax" AS  de_fax
+target		data:accommodation/{id} a schema:LodgingBusiness ; geo:asWKT "POINT ({longitude} {latitude})"^^geo:wktLiteral ; schema:email {email} ; schema:name {de_name}@de , {it_name}@it , {en_name}@en ; schema:telephone {de_phone} ; schema:faxNumber {de_fax} ; schema:description {it_desc}@it ; schema:alternateName {de_add_name}@de , {en_add_name}@en , {it_add_name}@it . 
+source		SELECT "Id" AS id, "Latitude" AS latitude, "Longitude" AS longitude,  "AccoDetail-de-Email" AS email, "AccoDetail-de-Name" AS de_name,  "AccoDetail-en-Name" AS en_name, "AccoDetail-it-Name" AS it_name, "AccoDetail-de-Phone" AS de_phone, "AccoDetail-de-Mobile"  AS mobile, "AccoDetail-de-Fax" AS  de_fax, "AccoDetail-it-Shortdesc" AS it_desc, "AccoDetail-de-NameAddition" AS de_add_name, "AccoDetail-en-NameAddition" as en_add_name,  "AccoDetail-it-NameAddition" as it_add_name
 			FROM "v_accommodationsopen"
 
 mappingId	Lodging business - geo
@@ -29,11 +29,13 @@ source		SELECT "Id" AS id, "Latitude" AS latitude, "Longitude" AS longitude, "Al
 			FROM "v_accommodationsopen"
 
 mappingId	LodgingBusiness - address
-target		data:address/accommodation/{id} a schema:PostalAddress ; schema:streetAddress {de_street}@de , {it_street}@it , {en_street}@en ; schema:postalCode {de_zip} ; schema:addressLocality {de_city}@de , {it_city}@it , {en_city}@en . data:accommodation/{id} schema:address data:address/accommodation/{id} . 
+target		data:address/accommodation/{id} a schema:PostalAddress ; schema:name {de_name}@de , {it_name}@it , {en_name}@en ; schema:alternateName {de_add_name}@de , {en_add_name}@en , {it_add_name}@it ; schema:streetAddress {de_street}@de , {it_street}@it , {en_street}@en ; schema:postalCode {de_zip} ; schema:addressLocality {de_city}@de , {it_city}@it , {en_city}@en . data:accommodation/{id} schema:address data:address/accommodation/{id} ; schema:email {email} ; schema:telephone {de_phone} ; schema:faxNumber {de_fax} . 
 source		SELECT "Id" AS id,
 			"AccoDetail-de-City" AS de_city, "AccoDetail-de-Zip" AS de_zip, "AccoDetail-de-Street" AS de_street,
 			"AccoDetail-it-City" AS it_city, "AccoDetail-it-Street" AS it_street,
-			"AccoDetail-en-City" AS en_city, "AccoDetail-en-Street" AS en_street
+			"AccoDetail-en-City" AS en_city, "AccoDetail-en-Street" AS en_street,
+			"AccoDetail-de-Name" AS de_name,  "AccoDetail-en-Name" AS en_name, "AccoDetail-it-Name" AS it_name, "AccoDetail-de-Phone" AS de_phone, "AccoDetail-de-Mobile"  AS mobile, "AccoDetail-de-Fax" AS  de_fax,
+			"AccoDetail-de-NameAddition" AS de_add_name, "AccoDetail-en-NameAddition" as en_add_name,  "AccoDetail-it-NameAddition" as it_add_name,   "AccoDetail-de-Email" AS email
 			FROM "v_accommodationsopen"
 
 mappingId	PensionHotel

--- a/vkg/odh.ttl
+++ b/vkg/odh.ttl
@@ -5,6 +5,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix data: <http://noi.example.org/data/> .
 @prefix obda: <https://w3id.org/obda/vocabulary#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <http://schema.org/> .
@@ -566,12 +567,7 @@ schema:identifier rdf:type owl:AnnotationProperty ;
 
 
 ###  http://schema.org/image
-schema:image rdf:type owl:AnnotationProperty ;
-             schema:domainIncludes schema:Thing ;
-             schema:rangeIncludes schema:ImageObject ,
-                                  schema:URL ;
-             rdfs:comment "An image of the item. This can be a [[URL]] or a fully described [[ImageObject]]."@en ;
-             rdfs:label "image"@en .
+schema:image rdf:type owl:AnnotationProperty .
 
 
 ###  http://schema.org/ingredients
@@ -1444,6 +1440,10 @@ schema:hasMenuItem rdf:type owl:ObjectProperty ;
                    rdfs:label "hasMenuItem"@en .
 
 
+###  http://schema.org/image
+schema:image rdf:type owl:ObjectProperty .
+
+
 ###  http://schema.org/occupancy
 schema:occupancy rdf:type owl:ObjectProperty ;
                  dc:source <https://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#STI_Accommodation_Ontology> ;
@@ -1526,6 +1526,14 @@ schema:addressLocality rdf:type owl:DatatypeProperty ;
                        schema:rangeIncludes schema:Text ;
                        rdfs:comment "The locality in which the street address is, and which is in the region. For example, Mountain View."@en ;
                        rdfs:label "addressLocality"@en .
+
+
+###  http://schema.org/alternateName
+schema:alternateName rdf:type owl:DatatypeProperty ;
+                     schema:domainIncludes schema:Thing ;
+                     schema:rangeIncludes schema:Text ;
+                     rdfs:comment "An alias for the item."@en ;
+                     rdfs:label "alternateName"@en .
 
 
 ###  http://schema.org/elevation
@@ -7430,8 +7438,8 @@ schema:Text rdfs:label "Text"@en ;
             rdfs:comment "Data type: Text."@en .
 
 
-schema:Time rdfs:label "Time"@en ;
-            rdfs:comment "A point in time recurring on multiple days in the form hh:mm:ss[Z|(+|-)hh:mm] (see [XML schema for details](http://www.w3.org/TR/xmlschema-2/#time))."@en .
+schema:Time rdfs:comment "A point in time recurring on multiple days in the form hh:mm:ss[Z|(+|-)hh:mm] (see [XML schema for details](http://www.w3.org/TR/xmlschema-2/#time))."@en ;
+            rdfs:label "Time"@en .
 
 
 schema:acceptedOffer schema:rangeIncludes schema:Offer ;
@@ -7462,22 +7470,22 @@ schema:accessCode rdfs:label "accessCode"@en ;
                   schema:rangeIncludes schema:Text .
 
 
-schema:accessMode schema:category "issue-1110"@en ;
-                  dc:source <https://github.com/schemaorg/schemaorg/issues/1100> ;
+schema:accessMode dc:source <https://github.com/schemaorg/schemaorg/issues/1100> ;
+                  schema:category "issue-1110"@en ;
                   schema:domainIncludes schema:CreativeWork ;
-                  rdfs:comment """The human sensory perceptual system or cognitive faculty through which a person may process or perceive information. Expected values include: auditory, tactile, textual, visual, colorDependent, chartOnVisual, chemOnVisual, diagramOnVisual, mathOnVisual, musicOnVisual, textOnVisual.
-      """@en ;
                   schema:rangeIncludes schema:Text ;
-                  rdfs:label "accessMode"@en .
+                  rdfs:label "accessMode"@en ;
+                  rdfs:comment """The human sensory perceptual system or cognitive faculty through which a person may process or perceive information. Expected values include: auditory, tactile, textual, visual, colorDependent, chartOnVisual, chemOnVisual, diagramOnVisual, mathOnVisual, musicOnVisual, textOnVisual.
+      """@en .
 
 
 schema:accessModeSufficient rdfs:label "accessModeSufficient"@en ;
                             schema:domainIncludes schema:CreativeWork ;
-                            schema:rangeIncludes schema:ItemList ;
-                            dc:source <https://github.com/schemaorg/schemaorg/issues/1100> ;
-                            schema:category "issue-1110"@en ;
                             rdfs:comment """A list of single or combined accessModes that are sufficient to understand all the intellectual content of a resource. Expected values include:  auditory, tactile, textual, visual.
-      """@en .
+      """@en ;
+                            schema:rangeIncludes schema:ItemList ;
+                            schema:category "issue-1110"@en ;
+                            dc:source <https://github.com/schemaorg/schemaorg/issues/1100> .
 
 
 schema:accessibilityAPI schema:rangeIncludes schema:Text ;
@@ -7506,8 +7514,8 @@ schema:accessibilityHazard schema:rangeIncludes schema:Text ;
 
 schema:accessibilitySummary rdfs:label "accessibilitySummary"@en ;
                             schema:domainIncludes schema:CreativeWork ;
-                            rdfs:comment "A human-readable summary of specific accessibility features or deficiencies, consistent with the other accessibility metadata but expressing subtleties such as \"short descriptions are present but long descriptions will be needed for non-visual users\" or \"short descriptions are present and no long descriptions are needed.\""@en ;
                             schema:category "issue-1110"@en ;
+                            rdfs:comment "A human-readable summary of specific accessibility features or deficiencies, consistent with the other accessibility metadata but expressing subtleties such as \"short descriptions are present but long descriptions will be needed for non-visual users\" or \"short descriptions are present and no long descriptions are needed.\""@en ;
                             schema:rangeIncludes schema:Text ;
                             dc:source <https://github.com/schemaorg/schemaorg/issues/1100> .
 
@@ -7525,8 +7533,8 @@ schema:acquiredFrom schema:domainIncludes schema:OwnershipInfo ;
                     rdfs:label "acquiredFrom"@en .
 
 
-schema:actionAccessibilityRequirement rdfs:comment "A set of requirements that a must be fulfilled in order to perform an Action. If more than one value is specied, fulfilling one set of requirements will allow the Action to be performed."@en ;
-                                      rdfs:label "actionAccessibilityRequirement"@en ;
+schema:actionAccessibilityRequirement rdfs:label "actionAccessibilityRequirement"@en ;
+                                      rdfs:comment "A set of requirements that a must be fulfilled in order to perform an Action. If more than one value is specied, fulfilling one set of requirements will allow the Action to be performed."@en ;
                                       dc:source <https://github.com/schemaorg/schemaorg/issues/1741> ;
                                       schema:category "issue-1741"@en ;
                                       schema:domainIncludes schema:ConsumeAction ;
@@ -7554,15 +7562,15 @@ schema:actionStatus schema:domainIncludes schema:Action ;
 
 schema:actor schema:domainIncludes schema:TVSeries ,
                                    schema:CreativeWorkSeason ,
-                                   schema:VideoGameSeries ,
                                    schema:Movie ;
              schema:rangeIncludes schema:Person ;
-             schema:domainIncludes schema:Clip ;
+             schema:domainIncludes schema:VideoGameSeries ,
+                                   schema:Clip ;
              rdfs:label "actor"@en ;
-             schema:domainIncludes schema:Event ,
-                                   schema:RadioSeries ;
+             schema:domainIncludes schema:Event ;
              rdfs:comment "An actor, e.g. in tv, radio, movie, video games etc., or in an event. Actors can be associated with individual items or with a series, episode, clip."@en ;
-             schema:domainIncludes schema:Episode ,
+             schema:domainIncludes schema:RadioSeries ,
+                                   schema:Episode ,
                                    schema:VideoGame ,
                                    schema:MovieSeries ,
                                    schema:VideoObject .
@@ -7573,9 +7581,9 @@ schema:actors schema:domainIncludes schema:Movie ,
                                     schema:RadioSeries ;
               rdfs:comment "An actor, e.g. in tv, radio, movie, video games etc. Actors can be associated with individual items or with a series, episode, clip."@en ;
               schema:domainIncludes schema:Clip ,
-                                    schema:VideoGame ,
                                     schema:VideoObject ;
               schema:supersededBy schema:actor ;
+              schema:domainIncludes schema:VideoGame ;
               schema:rangeIncludes schema:Person ;
               schema:domainIncludes schema:VideoGameSeries ;
               rdfs:label "actors"@en ;
@@ -7591,8 +7599,8 @@ schema:addOn schema:rangeIncludes schema:Offer ;
 
 schema:additionalName schema:domainIncludes schema:Person ;
                       rdfs:comment "An additional name for a Person, can be used for a middle name."@en ;
-                      rdfs:label "additionalName"@en ;
-                      schema:rangeIncludes schema:Text .
+                      schema:rangeIncludes schema:Text ;
+                      rdfs:label "additionalName"@en .
 
 
 schema:additionalNumberOfGuests rdfs:label "additionalNumberOfGuests"@en ;
@@ -7601,14 +7609,14 @@ schema:additionalNumberOfGuests rdfs:label "additionalNumberOfGuests"@en ;
                                 schema:rangeIncludes schema:Number .
 
 
-schema:additionalProperty schema:domainIncludes schema:QuantitativeValue ,
-                                                schema:Product ,
-                                                schema:QualitativeValue ,
-                                                schema:Place ;
-                          schema:rangeIncludes schema:PropertyValue ;
+schema:additionalProperty schema:domainIncludes schema:QuantitativeValue ;
                           rdfs:comment """A property-value pair representing an additional characteristics of the entitity, e.g. a product feature or another characteristic for which there is no matching property in schema.org.\\n\\nNote: Publishers should be aware that applications designed to use specific schema.org properties (e.g. http://schema.org/width, http://schema.org/color, http://schema.org/gtin13, ...) will typically expect such data to be provided using those properties, rather than using the generic property/value mechanism.
 """@en ;
-                          rdfs:label "additionalProperty"@en .
+                          schema:domainIncludes schema:Product ,
+                                                schema:QualitativeValue ,
+                                                schema:Place ;
+                          rdfs:label "additionalProperty"@en ;
+                          schema:rangeIncludes schema:PropertyValue .
 
 
 schema:addressRegion rdfs:comment "The region in which the locality is, and which is in the country. For example, California or another appropriate first-level [Administrative division](https://en.wikipedia.org/wiki/List_of_administrative_divisions_by_country) "@en ;
@@ -7639,15 +7647,15 @@ schema:agent rdfs:label "agent"@en ;
 
 
 schema:aggregateRating rdfs:comment "The overall rating, based on a collection of reviews or ratings, of the item."@en ;
-                       schema:domainIncludes schema:Brand ;
                        rdfs:label "aggregateRating"@en ;
-                       schema:domainIncludes schema:Service ,
+                       schema:domainIncludes schema:Brand ,
+                                             schema:Service ,
                                              schema:Place ,
-                                             schema:Event ,
-                                             schema:Product ,
-                                             schema:CreativeWork ;
+                                             schema:Event ;
                        schema:rangeIncludes schema:AggregateRating ;
-                       schema:domainIncludes schema:Offer ,
+                       schema:domainIncludes schema:Product ,
+                                             schema:CreativeWork ,
+                                             schema:Offer ,
                                              schema:Organization .
 
 
@@ -7685,8 +7693,8 @@ schema:albumReleaseType schema:domainIncludes schema:MusicAlbum ;
                         rdfs:comment "The kind of release which this album is: single, EP or album."@en .
 
 
-schema:albums rdfs:comment "A collection of music albums."@en ;
-              rdfs:label "albums"@en ;
+schema:albums rdfs:label "albums"@en ;
+              rdfs:comment "A collection of music albums."@en ;
               schema:supersededBy schema:album ;
               schema:domainIncludes schema:MusicGroup ;
               schema:rangeIncludes schema:MusicAlbum .
@@ -7696,12 +7704,6 @@ schema:alignmentType schema:rangeIncludes schema:Text ;
                      rdfs:label "alignmentType"@en ;
                      rdfs:comment "A category of alignment between the learning resource and the framework node. Recommended values include: 'assesses', 'teaches', 'requires', 'textComplexity', 'readingLevel', 'educationalSubject', and 'educationalLevel'."@en ;
                      schema:domainIncludes schema:AlignmentObject .
-
-
-schema:alternateName schema:rangeIncludes schema:Text ;
-                     rdfs:comment "An alias for the item."@en ;
-                     schema:domainIncludes schema:Thing ;
-                     rdfs:label "alternateName"@en .
 
 
 schema:alternativeHeadline schema:domainIncludes schema:CreativeWork ;
@@ -7721,29 +7723,29 @@ schema:alumni schema:domainIncludes schema:Organization ;
 schema:alumniOf schema:rangeIncludes schema:EducationalOrganization ,
                                      schema:Organization ;
                 rdfs:label "alumniOf"@en ;
-                schema:domainIncludes schema:Person ;
                 rdfs:comment "An organization that the person is an alumni of."@en ;
+                schema:domainIncludes schema:Person ;
                 schema:inverseOf schema:alumni .
 
 
 schema:amenityFeature rdfs:comment "An amenity feature (e.g. a characteristic or service) of the Accommodation. This generic property does not make a statement about whether the feature is included in an offer for the main accommodation or available at extra costs."@en ;
                       rdfs:label "amenityFeature"@en ;
-                      schema:domainIncludes schema:Accommodation ,
-                                            schema:Place ;
+                      schema:domainIncludes schema:Accommodation ;
                       schema:rangeIncludes schema:LocationFeatureSpecification ;
-                      schema:domainIncludes schema:LodgingBusiness ;
+                      schema:domainIncludes schema:Place ,
+                                            schema:LodgingBusiness ;
                       dc:source <https://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#STI_Accommodation_Ontology> .
 
 
 schema:amount rdfs:label "amount"@en ;
               dc:source <https://github.com/schemaorg/schemaorg/issues/1698> ;
-              schema:domainIncludes schema:DatedMoneySpecification ;
-              schema:rangeIncludes schema:MonetaryAmount ;
-              schema:domainIncludes schema:InvestmentOrDeposit ;
               schema:category "issue-1698"@en ;
+              schema:domainIncludes schema:InvestmentOrDeposit ,
+                                    schema:DatedMoneySpecification ;
+              schema:rangeIncludes schema:MonetaryAmount ;
               schema:domainIncludes schema:LoanOrCredit ;
-              schema:rangeIncludes schema:Number ;
-              rdfs:comment "The amount of money."@en .
+              rdfs:comment "The amount of money."@en ;
+              schema:rangeIncludes schema:Number .
 
 
 schema:amountOfThisGood schema:domainIncludes schema:TypeAndQuantityNode ;
@@ -7762,8 +7764,8 @@ schema:annualPercentageRate dc:source <http://www.w3.org/wiki/WebSchemas/SchemaD
 
 schema:answerCount rdfs:label "answerCount"@en ;
                    schema:rangeIncludes schema:Integer ;
-                   rdfs:comment "The number of answers this question has received."@en ;
-                   schema:domainIncludes schema:Question .
+                   schema:domainIncludes schema:Question ;
+                   rdfs:comment "The number of answers this question has received."@en .
 
 
 schema:application schema:rangeIncludes schema:SoftwareApplication ;
@@ -7781,8 +7783,8 @@ schema:applicationCategory schema:rangeIncludes schema:Text ;
 
 
 schema:applicationSubCategory rdfs:label "applicationSubCategory"@en ;
-                              schema:rangeIncludes schema:URL ;
                               schema:domainIncludes schema:SoftwareApplication ;
+                              schema:rangeIncludes schema:URL ;
                               rdfs:comment "Subcategory of the application, e.g. 'Arcade Game'."@en ;
                               schema:rangeIncludes schema:Text .
 
@@ -7834,19 +7836,19 @@ schema:arrivalGate rdfs:comment "Identifier of the flight's arrival gate."@en ;
 
 schema:arrivalPlatform schema:domainIncludes schema:TrainTrip ;
                        schema:rangeIncludes schema:Text ;
-                       rdfs:label "arrivalPlatform"@en ;
-                       rdfs:comment "The platform where the train arrives."@en .
+                       rdfs:comment "The platform where the train arrives."@en ;
+                       rdfs:label "arrivalPlatform"@en .
 
 
 schema:arrivalStation rdfs:comment "The station where the train trip ends."@en ;
                       rdfs:label "arrivalStation"@en ;
-                      schema:domainIncludes schema:TrainTrip ;
-                      schema:rangeIncludes schema:TrainStation .
+                      schema:rangeIncludes schema:TrainStation ;
+                      schema:domainIncludes schema:TrainTrip .
 
 
 schema:arrivalTerminal schema:rangeIncludes schema:Text ;
-                       rdfs:label "arrivalTerminal"@en ;
                        schema:domainIncludes schema:Flight ;
+                       rdfs:label "arrivalTerminal"@en ;
                        rdfs:comment "Identifier of the flight's arrival terminal."@en .
 
 
@@ -7886,20 +7888,20 @@ schema:articleSection schema:rangeIncludes schema:Text ;
 schema:artworkSurface schema:rangeIncludes schema:URL ;
                       rdfs:comment "The supporting materials for the artwork, e.g. Canvas, Paper, Wood, Board, etc."@en ;
                       rdfs:label "artworkSurface"@en ;
-                      schema:rangeIncludes schema:Text ;
-                      schema:domainIncludes schema:VisualArtwork .
+                      schema:domainIncludes schema:VisualArtwork ;
+                      schema:rangeIncludes schema:Text .
 
 
 schema:assembly rdfs:label "assembly"@en ;
-                schema:rangeIncludes schema:Text ;
                 schema:domainIncludes schema:APIReference ;
+                schema:rangeIncludes schema:Text ;
                 schema:supersededBy schema:executableLibraryName ;
                 rdfs:comment "Library file name e.g., mscorlib.dll, system.web.dll."@en .
 
 
 schema:assemblyVersion rdfs:comment "Associated product/technology version. e.g., .NET Framework 4.5."@en ;
-                       rdfs:label "assemblyVersion"@en ;
                        schema:rangeIncludes schema:Text ;
+                       rdfs:label "assemblyVersion"@en ;
                        schema:domainIncludes schema:APIReference .
 
 
@@ -7921,8 +7923,8 @@ schema:athlete schema:rangeIncludes schema:Person ;
                schema:domainIncludes schema:SportsTeam .
 
 
-schema:attendee rdfs:comment "A person or organization attending the event."@en ;
-                rdfs:label "attendee"@en ;
+schema:attendee rdfs:label "attendee"@en ;
+                rdfs:comment "A person or organization attending the event."@en ;
                 schema:domainIncludes schema:Event ;
                 schema:rangeIncludes schema:Person ,
                                      schema:Organization .
@@ -7943,8 +7945,8 @@ schema:audience schema:domainIncludes schema:CreativeWork ;
                                       schema:PlayAction ;
                 rdfs:label "audience"@en ;
                 rdfs:comment "An intended audience, i.e. a group for whom something was created."@en ;
-                schema:domainIncludes schema:Event ,
-                                      schema:LodgingBusiness .
+                schema:domainIncludes schema:LodgingBusiness ,
+                                      schema:Event .
 
 
 schema:audienceType schema:domainIncludes schema:Audience ;
@@ -7968,12 +7970,12 @@ schema:authenticator schema:rangeIncludes schema:Organization ;
                      dc:source <https://github.com/schemaorg/schemaorg/issues/1741> .
 
 
-schema:author schema:rangeIncludes schema:Person ,
-                                   schema:Organization ;
-              schema:domainIncludes schema:CreativeWork ,
-                                    schema:Rating ;
-              rdfs:label "author"@en ;
-              rdfs:comment "The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably."@en .
+schema:author schema:rangeIncludes schema:Person ;
+              schema:domainIncludes schema:CreativeWork ;
+              schema:rangeIncludes schema:Organization ;
+              schema:domainIncludes schema:Rating ;
+              rdfs:comment "The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably."@en ;
+              rdfs:label "author"@en .
 
 
 schema:availability schema:rangeIncludes schema:ItemAvailability ;
@@ -7998,9 +8000,9 @@ schema:availabilityEnds schema:domainIncludes schema:Offer ;
 schema:availabilityStarts schema:domainIncludes schema:Offer ,
                                                 schema:Demand ;
                           dc:source <https://github.com/schemaorg/schemaorg/issues/1741> ;
+                          schema:rangeIncludes schema:Date ;
                           schema:category "issue-1741"@en ;
-                          schema:rangeIncludes schema:Date ,
-                                               schema:DateTime ,
+                          schema:rangeIncludes schema:DateTime ,
                                                schema:Time ;
                           schema:domainIncludes schema:ActionAccessSpecification ;
                           rdfs:label "availabilityStarts"@en ;
@@ -8032,14 +8034,14 @@ schema:availableLanguage rdfs:label "availableLanguage"@en ;
                          schema:domainIncludes schema:ServiceChannel ,
                                                schema:TouristAttraction ,
                                                schema:ContactPoint ;
-                         schema:rangeIncludes schema:Text ;
-                         rdfs:comment "A language someone may use with or at the item, service or place. Please use one of the language codes from the [IETF BCP 47 standard](http://tools.ietf.org/html/bcp47). See also [[inLanguage]]"@en .
+                         rdfs:comment "A language someone may use with or at the item, service or place. Please use one of the language codes from the [IETF BCP 47 standard](http://tools.ietf.org/html/bcp47). See also [[inLanguage]]"@en ;
+                         schema:rangeIncludes schema:Text .
 
 
 schema:availableOnDevice rdfs:comment "Device required to run the application. Used in cases where a specific make/model is required to run the application."@en ;
+                         rdfs:label "availableOnDevice"@en ;
                          schema:rangeIncludes schema:Text ;
-                         schema:domainIncludes schema:SoftwareApplication ;
-                         rdfs:label "availableOnDevice"@en .
+                         schema:domainIncludes schema:SoftwareApplication .
 
 
 schema:availableThrough rdfs:comment "After this date, the item will no longer be available for pickup."@en ;
@@ -8079,17 +8081,17 @@ schema:baseSalary schema:rangeIncludes schema:PriceSpecification ;
 
 schema:bed dc:source <https://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#STI_Accommodation_Ontology> ;
            schema:domainIncludes schema:HotelRoom ;
-           schema:rangeIncludes schema:Text ,
-                                schema:BedType ;
+           schema:rangeIncludes schema:Text ;
            rdfs:comment """The type of bed or beds included in the accommodation. For the single case of just one bed of a certain type, you use bed directly with a text.
       If you want to indicate the quantity of a certain kind of bed, use an instance of BedDetails. For more detailed information, use the amenityFeature property."""@en ;
+           schema:rangeIncludes schema:BedType ;
            schema:domainIncludes schema:Suite ;
            schema:rangeIncludes schema:BedDetails ;
            rdfs:label "bed"@en .
 
 
-schema:beforeMedia schema:domainIncludes schema:HowToDirection ;
-                   schema:rangeIncludes schema:MediaObject ;
+schema:beforeMedia schema:rangeIncludes schema:MediaObject ;
+                   schema:domainIncludes schema:HowToDirection ;
                    rdfs:label "beforeMedia"@en ;
                    schema:rangeIncludes schema:URL ;
                    rdfs:comment "A media object representing the circumstances before performing this direction."@en .
@@ -8127,14 +8129,14 @@ schema:billingPeriod schema:rangeIncludes schema:Duration ;
                      rdfs:comment "The time interval used to compute the invoice."@en .
 
 
-schema:birthDate schema:domainIncludes schema:Person ;
-                 schema:rangeIncludes schema:Date ;
+schema:birthDate schema:rangeIncludes schema:Date ;
+                 schema:domainIncludes schema:Person ;
                  rdfs:comment "Date of birth."@en ;
                  rdfs:label "birthDate"@en .
 
 
-schema:birthPlace schema:rangeIncludes schema:Place ;
-                  rdfs:comment "The place where the person was born."@en ;
+schema:birthPlace rdfs:comment "The place where the person was born."@en ;
+                  schema:rangeIncludes schema:Place ;
                   schema:domainIncludes schema:Person ;
                   rdfs:label "birthPlace"@en .
 
@@ -8204,9 +8206,9 @@ schema:box rdfs:label "box"@en ;
 
 
 schema:branchCode rdfs:label "branchCode"@en ;
+                  schema:domainIncludes schema:Place ;
                   rdfs:comment """A short textual code (also called \"store code\") that uniquely identifies a place of business. The code is typically assigned by the parentOrganization and used in structured URLs.\\n\\nFor example, in the URL http://www.starbucks.co.uk/store-locator/etc/detail/3047 the code \"3047\" is a branchCode for a particular branch.
       """@en ;
-                  schema:domainIncludes schema:Place ;
                   schema:rangeIncludes schema:Text .
 
 
@@ -8217,8 +8219,8 @@ schema:branchOf rdfs:comment "The larger organization that this local business i
                 schema:rangeIncludes schema:Organization .
 
 
-schema:brand rdfs:comment "The brand(s) associated with a product or service, or the brand(s) maintained by an organization or business person."@en ;
-             schema:rangeIncludes schema:Organization ;
+schema:brand schema:rangeIncludes schema:Organization ;
+             rdfs:comment "The brand(s) associated with a product or service, or the brand(s) maintained by an organization or business person."@en ;
              schema:domainIncludes schema:Service ;
              schema:rangeIncludes schema:Brand ;
              schema:domainIncludes schema:Person ,
@@ -8241,8 +8243,8 @@ schema:broadcastAffiliateOf schema:domainIncludes schema:BroadcastService ;
 
 
 schema:broadcastChannelId rdfs:comment "The unique address by which the BroadcastService can be identified in a provider lineup. In US, this is typically a number."@en ;
-                          rdfs:label "broadcastChannelId"@en ;
                           schema:rangeIncludes schema:Text ;
+                          rdfs:label "broadcastChannelId"@en ;
                           schema:domainIncludes schema:BroadcastChannel .
 
 
@@ -8254,8 +8256,8 @@ schema:broadcastDisplayName rdfs:label "broadcastDisplayName"@en ;
 
 schema:broadcastFrequency schema:rangeIncludes schema:BroadcastFrequencySpecification ;
                           rdfs:comment "The frequency used for over-the-air broadcasts. Numeric values or simple ranges e.g. 87-99. In addition a shortcut idiom is supported for frequences of AM and FM radio channels, e.g. \"87 FM\"."@en ;
-                          schema:category "issue-1004"@en ;
                           schema:rangeIncludes schema:Text ;
+                          schema:category "issue-1004"@en ;
                           schema:domainIncludes schema:BroadcastChannel ;
                           rdfs:label "broadcastFrequency"@en ;
                           schema:domainIncludes schema:BroadcastService ;
@@ -8291,18 +8293,18 @@ schema:broadcastTimezone schema:domainIncludes schema:BroadcastService ;
 
 schema:broadcaster rdfs:label "broadcaster"@en ;
                    rdfs:comment "The organization owning or operating the broadcast service."@en ;
-                   schema:domainIncludes schema:BroadcastService ;
-                   schema:rangeIncludes schema:Organization .
+                   schema:rangeIncludes schema:Organization ;
+                   schema:domainIncludes schema:BroadcastService .
 
 
 schema:broker schema:rangeIncludes schema:Organization ,
                                    schema:Person ;
-              schema:domainIncludes schema:Order ,
-                                    schema:Reservation ,
+              schema:domainIncludes schema:Reservation ,
+                                    schema:Order ,
                                     schema:Service ,
                                     schema:Invoice ;
-              rdfs:label "broker"@en ;
-              rdfs:comment "An entity that arranges for an exchange between a buyer and a seller.  In most cases a broker never acquires or releases ownership of a product or service involved in an exchange.  If it is not clear whether an entity is a broker, seller, or buyer, the latter two terms are preferred."@en .
+              rdfs:comment "An entity that arranges for an exchange between a buyer and a seller.  In most cases a broker never acquires or releases ownership of a product or service involved in an exchange.  If it is not clear whether an entity is a broker, seller, or buyer, the latter two terms are preferred."@en ;
+              rdfs:label "broker"@en .
 
 
 schema:browserRequirements schema:domainIncludes schema:WebApplication ;
@@ -8323,8 +8325,8 @@ schema:busNumber rdfs:label "busNumber"@en ;
                  rdfs:comment "The unique identifier for the bus."@en .
 
 
-schema:businessFunction schema:rangeIncludes schema:BusinessFunction ;
-                        rdfs:label "businessFunction"@en ;
+schema:businessFunction rdfs:label "businessFunction"@en ;
+                        schema:rangeIncludes schema:BusinessFunction ;
                         schema:domainIncludes schema:Offer ;
                         rdfs:comment "The business function (e.g. sell, lease, repair, dispose) of the offer or component of a bundle (TypeAndQuantityNode). The default is http://purl.org/goodrelations/v1#Sell."@en ;
                         schema:domainIncludes schema:TypeAndQuantityNode ,
@@ -8332,9 +8334,9 @@ schema:businessFunction schema:rangeIncludes schema:BusinessFunction ;
 
 
 schema:byArtist schema:rangeIncludes schema:MusicGroup ;
-                schema:domainIncludes schema:MusicRecording ;
+                schema:domainIncludes schema:MusicRecording ,
+                                      schema:MusicAlbum ;
                 rdfs:comment "The artist that performed this album or recording."@en ;
-                schema:domainIncludes schema:MusicAlbum ;
                 schema:rangeIncludes schema:Person ;
                 rdfs:label "byArtist"@en .
 
@@ -8345,9 +8347,9 @@ schema:calories rdfs:comment "The number of calories."@en ;
                 schema:domainIncludes schema:NutritionInformation .
 
 
-schema:caption schema:rangeIncludes schema:MediaObject ;
+schema:caption schema:rangeIncludes schema:Text ,
+                                    schema:MediaObject ;
                rdfs:label "caption"@en ;
-               schema:rangeIncludes schema:Text ;
                schema:domainIncludes schema:ImageObject ,
                                      schema:VideoObject ,
                                      schema:AudioObject ;
@@ -8367,8 +8369,8 @@ schema:cargoVolume rdfs:label "cargoVolume"@en ;
                    schema:rangeIncludes schema:QuantitativeValue .
 
 
-schema:carrier schema:domainIncludes schema:Flight ;
-               schema:supersededBy schema:provider ;
+schema:carrier schema:supersededBy schema:provider ;
+               schema:domainIncludes schema:Flight ;
                schema:rangeIncludes schema:Organization ;
                rdfs:label "carrier"@en ;
                schema:domainIncludes schema:ParcelDelivery ;
@@ -8382,8 +8384,8 @@ schema:carrierRequirements schema:domainIncludes schema:MobileApplication ;
 
 
 schema:catalog schema:domainIncludes schema:Dataset ;
-               rdfs:comment "A data catalog which contains this dataset."@en ;
                rdfs:label "catalog"@en ;
+               rdfs:comment "A data catalog which contains this dataset."@en ;
                schema:rangeIncludes schema:DataCatalog ;
                schema:supersededBy schema:includedInDataCatalog .
 
@@ -8401,8 +8403,8 @@ schema:character rdfs:label "character"@en ;
                  schema:domainIncludes schema:CreativeWork .
 
 
-schema:characterAttribute schema:domainIncludes schema:VideoGameSeries ;
-                          rdfs:label "characterAttribute"@en ;
+schema:characterAttribute rdfs:label "characterAttribute"@en ;
+                          schema:domainIncludes schema:VideoGameSeries ;
                           schema:rangeIncludes schema:Thing ;
                           rdfs:comment "A piece of data that represents a particular aspect of a fictional character (skill, power, character points, advantage, disadvantage)."@en ;
                           schema:domainIncludes schema:Game .
@@ -8416,14 +8418,14 @@ schema:characterName schema:domainIncludes schema:PerformanceRole ;
 
 schema:cheatCode schema:domainIncludes schema:VideoGame ;
                  rdfs:label "cheatCode"@en ;
-                 schema:domainIncludes schema:VideoGameSeries ;
                  schema:rangeIncludes schema:CreativeWork ;
+                 schema:domainIncludes schema:VideoGameSeries ;
                  rdfs:comment "Cheat codes to the game."@en .
 
 
-schema:checkinTime rdfs:label "checkinTime"@en ;
-                   schema:rangeIncludes schema:DateTime ,
-                                        schema:Time ;
+schema:checkinTime schema:rangeIncludes schema:DateTime ;
+                   rdfs:label "checkinTime"@en ;
+                   schema:rangeIncludes schema:Time ;
                    rdfs:comment "The earliest someone may check into a lodging establishment."@en ;
                    schema:domainIncludes schema:LodgingBusiness ,
                                          schema:LodgingReservation .
@@ -8462,8 +8464,8 @@ schema:cholesterolContent rdfs:label "cholesterolContent"@en ;
 
 
 schema:circle schema:rangeIncludes schema:Text ;
-              rdfs:comment "A circle is the circular region of a specified radius centered at a specified latitude and longitude. A circle is expressed as a pair followed by a radius in meters."@en ;
               rdfs:label "circle"@en ;
+              rdfs:comment "A circle is the circular region of a specified radius centered at a specified latitude and longitude. A circle is expressed as a pair followed by a radius in meters."@en ;
               schema:domainIncludes schema:GeoShape .
 
 
@@ -8478,8 +8480,8 @@ schema:claimReviewed rdfs:label "claimReviewed"@en ;
                      schema:rangeIncludes schema:Text ;
                      rdfs:comment "A short summary of the specific claims reviewed in a ClaimReview."@en ;
                      dc:source <https://github.com/schemaorg/schemaorg/issues/1061> ;
-                     schema:category "issue-1061"@en ;
-                     schema:domainIncludes schema:ClaimReview .
+                     schema:domainIncludes schema:ClaimReview ;
+                     schema:category "issue-1061"@en .
 
 
 schema:closes schema:domainIncludes schema:OpeningHoursSpecification ;
@@ -8527,8 +8529,8 @@ schema:color schema:domainIncludes schema:Product ;
 
 
 schema:comment rdfs:comment "Comments, typically from users."@en ;
-               rdfs:label "comment"@en ;
                schema:domainIncludes schema:RsvpAction ;
+               rdfs:label "comment"@en ;
                schema:rangeIncludes schema:Comment ;
                schema:domainIncludes schema:CreativeWork .
 
@@ -8541,19 +8543,19 @@ schema:commentCount schema:rangeIncludes schema:Integer ;
 
 schema:commentText schema:rangeIncludes schema:Text ;
                    rdfs:comment "The text of the UserComment."@en ;
-                   rdfs:label "commentText"@en ;
-                   schema:domainIncludes schema:UserComments .
+                   schema:domainIncludes schema:UserComments ;
+                   rdfs:label "commentText"@en .
 
 
-schema:commentTime schema:rangeIncludes schema:DateTime ,
-                                        schema:Date ;
+schema:commentTime schema:rangeIncludes schema:Date ,
+                                        schema:DateTime ;
                    schema:domainIncludes schema:UserComments ;
                    rdfs:comment "The time at which the UserComment was made."@en ;
                    rdfs:label "commentTime"@en .
 
 
-schema:composer schema:domainIncludes schema:MusicComposition ,
-                                      schema:Event ;
+schema:composer schema:domainIncludes schema:Event ,
+                                      schema:MusicComposition ;
                 schema:rangeIncludes schema:Person ,
                                      schema:Organization ;
                 rdfs:label "composer"@en ;
@@ -8584,21 +8586,21 @@ schema:contactPoints rdfs:comment "A contact point for a person or organization.
 
 schema:contactType schema:domainIncludes schema:ContactPoint ;
                    rdfs:comment "A person or organization can have different contact points, for different purposes. For example, a sales contact point, a PR contact point and so on. This property is used to specify the kind of contact point."@en ;
-                   rdfs:label "contactType"@en ;
-                   schema:rangeIncludes schema:Text .
+                   schema:rangeIncludes schema:Text ;
+                   rdfs:label "contactType"@en .
 
 
-schema:containedIn schema:supersededBy schema:containedInPlace ;
-                   schema:domainIncludes schema:Place ;
+schema:containedIn schema:domainIncludes schema:Place ;
+                   schema:supersededBy schema:containedInPlace ;
                    rdfs:comment "The basic containment relation between a place and one that contains it."@en ;
-                   rdfs:label "containedIn"@en ;
-                   schema:rangeIncludes schema:Place .
+                   schema:rangeIncludes schema:Place ;
+                   rdfs:label "containedIn"@en .
 
 
 schema:contentRating schema:rangeIncludes schema:Text ;
                      rdfs:comment "Official rating of a piece of content&#x2014;for example,'MPAA PG-13'."@en ;
-                     schema:domainIncludes schema:CreativeWork ;
                      schema:rangeIncludes schema:Rating ;
+                     schema:domainIncludes schema:CreativeWork ;
                      rdfs:label "contentRating"@en .
 
 
@@ -8641,8 +8643,8 @@ schema:copyrightHolder schema:rangeIncludes schema:Organization ,
                        rdfs:comment "The party holding the legal copyright to the CreativeWork."@en .
 
 
-schema:copyrightYear rdfs:label "copyrightYear"@en ;
-                     rdfs:comment "The year during which the claimed copyright for the CreativeWork was first asserted."@en ;
+schema:copyrightYear rdfs:comment "The year during which the claimed copyright for the CreativeWork was first asserted."@en ;
+                     rdfs:label "copyrightYear"@en ;
                      schema:rangeIncludes schema:Number ;
                      schema:domainIncludes schema:CreativeWork .
 
@@ -8674,16 +8676,16 @@ schema:courseCode rdfs:label "courseCode"@en ;
                   schema:rangeIncludes schema:Text .
 
 
-schema:courseMode schema:domainIncludes schema:CourseInstance ;
-                  rdfs:label "courseMode"@en ;
+schema:courseMode rdfs:label "courseMode"@en ;
+                  schema:domainIncludes schema:CourseInstance ;
                   schema:rangeIncludes schema:Text ;
                   rdfs:comment "The medium or means of delivery of the course instance or the mode of study, either as a text label (e.g. \"online\", \"onsite\" or \"blended\"; \"synchronous\" or \"asynchronous\"; \"full-time\" or \"part-time\") or as a URL reference to a term from a controlled vocabulary (e.g. https://ceds.ed.gov/element/001311#Asynchronous )."@en ;
                   schema:rangeIncludes schema:URL .
 
 
-schema:coursePrerequisites rdfs:label "coursePrerequisites"@en ;
-                           schema:rangeIncludes schema:Text ,
-                                                schema:Course ;
+schema:coursePrerequisites schema:rangeIncludes schema:Text ;
+                           rdfs:label "coursePrerequisites"@en ;
+                           schema:rangeIncludes schema:Course ;
                            schema:domainIncludes schema:Course ;
                            schema:rangeIncludes schema:AlignmentObject ;
                            rdfs:comment "Requirements for taking the Course. May be completion of another [[Course]] or a textual description like \"permission of instructor\". Requirements may be a pre-requisite competency, referenced using [[AlignmentObject]]."@en .
@@ -8697,8 +8699,8 @@ schema:coverageEndTime rdfs:label "coverageEndTime"@en ;
 
 schema:coverageStartTime rdfs:label "coverageStartTime"@en ;
                          schema:domainIncludes schema:LiveBlogPosting ;
-                         schema:rangeIncludes schema:DateTime ;
-                         rdfs:comment "The time when the live blog will begin covering the Event. Note that coverage may begin before the Event's start time. The LiveBlogPosting may also be created before coverage begins."@en .
+                         rdfs:comment "The time when the live blog will begin covering the Event. Note that coverage may begin before the Event's start time. The LiveBlogPosting may also be created before coverage begins."@en ;
+                         schema:rangeIncludes schema:DateTime .
 
 
 schema:creator schema:domainIncludes schema:CreativeWork ;
@@ -8727,8 +8729,8 @@ schema:cssSelector schema:domainIncludes schema:SpeakableSpecification ;
 
 
 schema:currenciesAccepted rdfs:label "currenciesAccepted"@en ;
-                          schema:rangeIncludes schema:Text ;
                           rdfs:comment "The currency accepted.\\n\\nUse standard formats: [ISO 4217 currency format](http://en.wikipedia.org/wiki/ISO_4217) e.g. \"USD\"; [Ticker symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies) for cryptocurrencies e.g. \"BTC\"; well known names for [Local Exchange Tradings Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system) (LETS) and other currency types e.g. \"Ithaca HOUR\"."@en ;
+                          schema:rangeIncludes schema:Text ;
                           schema:domainIncludes schema:LocalBusiness .
 
 
@@ -8772,8 +8774,8 @@ schema:datasetTimeInterval schema:domainIncludes schema:Dataset ;
 
 schema:dateCreated schema:rangeIncludes schema:Date ;
                    rdfs:label "dateCreated"@en ;
-                   schema:domainIncludes schema:CreativeWork ,
-                                         schema:DataFeedItem ;
+                   schema:domainIncludes schema:DataFeedItem ,
+                                         schema:CreativeWork ;
                    schema:rangeIncludes schema:DateTime ;
                    rdfs:comment "The date on which the CreativeWork was created or the item was added to a DataFeed."@en .
 
@@ -8796,13 +8798,13 @@ schema:dateModified schema:domainIncludes schema:DataFeedItem ;
                     rdfs:label "dateModified"@en ;
                     schema:rangeIncludes schema:DateTime ;
                     rdfs:comment "The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed."@en ;
-                    schema:domainIncludes schema:CreativeWork ;
-                    schema:rangeIncludes schema:Date .
+                    schema:rangeIncludes schema:Date ;
+                    schema:domainIncludes schema:CreativeWork .
 
 
-schema:datePosted rdfs:comment "Publication date for the job posting."@en ;
+schema:datePosted schema:domainIncludes schema:JobPosting ;
+                  rdfs:comment "Publication date for the job posting."@en ;
                   rdfs:label "datePosted"@en ;
-                  schema:domainIncludes schema:JobPosting ;
                   schema:rangeIncludes schema:Date .
 
 
@@ -8813,9 +8815,9 @@ schema:datePublished schema:rangeIncludes schema:Date ;
 
 
 schema:dateRead schema:domainIncludes schema:Message ;
-                schema:rangeIncludes schema:Date ;
+                schema:rangeIncludes schema:Date ,
+                                     schema:DateTime ;
                 rdfs:label "dateRead"@en ;
-                schema:rangeIncludes schema:DateTime ;
                 rdfs:comment "The date/time at which the message has been read by the recipient if a single recipient exists."@en .
 
 
@@ -8840,13 +8842,13 @@ schema:dateVehicleFirstRegistered rdfs:comment "The date of the first registrati
 
 schema:dateline schema:domainIncludes schema:NewsArticle ;
                 schema:rangeIncludes schema:Text ;
+                rdfs:label "dateline"@en ;
                 rdfs:comment """A [dateline](https://en.wikipedia.org/wiki/Dateline) is a brief piece of text included in news articles that describes where and when the story was written or filed though the date is often omitted. Sometimes only a placename is provided.
 
 Structured representations of dateline-related information can also be expressed more explicitly using [[locationCreated]] (which represents where a work was created e.g. where a news report was written).  For location depicted or described in the content, use [[contentLocation]].
 
 Dateline summaries are oriented more towards human readers than towards automated processing, and can vary substantially. Some examples: \"BEIRUT, Lebanon, June 2.\", \"Paris, France\", \"December 19, 2017 11:43AM Reporting from Washington\", \"Beijing/Moscow\", \"QUEZON CITY, Philippines\".
-      """@en ;
-                rdfs:label "dateline"@en .
+      """@en .
 
 
 schema:dayOfWeek schema:domainIncludes schema:OpeningHoursSpecification ;
@@ -8943,8 +8945,8 @@ schema:departureTime rdfs:comment "The expected departure time."@en ;
                      schema:domainIncludes schema:Trip .
 
 
-schema:dependencies rdfs:label "dependencies"@en ;
-                    rdfs:comment "Prerequisites needed to fulfill steps in article."@en ;
+schema:dependencies rdfs:comment "Prerequisites needed to fulfill steps in article."@en ;
+                    rdfs:label "dependencies"@en ;
                     schema:rangeIncludes schema:Text ;
                     schema:domainIncludes schema:TechArticle .
 
@@ -8960,17 +8962,17 @@ schema:depth schema:domainIncludes schema:VisualArtwork ;
 schema:device schema:domainIncludes schema:SoftwareApplication ;
               schema:rangeIncludes schema:Text ;
               rdfs:label "device"@en ;
-              rdfs:comment "Device required to run the application. Used in cases where a specific make/model is required to run the application."@en ;
-              schema:supersededBy schema:availableOnDevice .
+              schema:supersededBy schema:availableOnDevice ;
+              rdfs:comment "Device required to run the application. Used in cases where a specific make/model is required to run the application."@en .
 
 
-schema:director schema:domainIncludes schema:Event ,
-                                      schema:TVSeries ,
-                                      schema:Clip ,
+schema:director schema:domainIncludes schema:TVSeries ,
+                                      schema:Event ,
                                       schema:RadioSeries ,
-                                      schema:VideoGameSeries ;
+                                      schema:Clip ;
                 schema:rangeIncludes schema:Person ;
-                schema:domainIncludes schema:CreativeWorkSeason ,
+                schema:domainIncludes schema:VideoGameSeries ,
+                                      schema:CreativeWorkSeason ,
                                       schema:VideoObject ,
                                       schema:VideoGame ;
                 rdfs:label "director"@en ;
@@ -8990,15 +8992,15 @@ schema:directors schema:domainIncludes schema:Movie ,
                                        schema:VideoGameSeries ;
                  schema:rangeIncludes schema:Person ;
                  rdfs:label "directors"@en ;
-                 schema:domainIncludes schema:RadioSeries ,
-                                       schema:Episode ;
+                 schema:domainIncludes schema:Episode ,
+                                       schema:RadioSeries ;
                  schema:supersededBy schema:director .
 
 
 schema:discount schema:rangeIncludes schema:Number ,
                                      schema:Text ;
-                schema:domainIncludes schema:Order ;
                 rdfs:label "discount"@en ;
+                schema:domainIncludes schema:Order ;
                 rdfs:comment "Any discount applied (to an Order)."@en .
 
 
@@ -9059,9 +9061,9 @@ schema:downloadUrl rdfs:label "downloadUrl"@en ;
 
 
 schema:downvoteCount schema:rangeIncludes schema:Integer ;
-                     schema:domainIncludes schema:Question ;
                      rdfs:comment "The number of downvotes this question, answer or comment has received from the community."@en ;
-                     schema:domainIncludes schema:Comment ;
+                     schema:domainIncludes schema:Comment ,
+                                           schema:Question ;
                      rdfs:label "downvoteCount"@en .
 
 
@@ -9069,14 +9071,14 @@ schema:driveWheelConfiguration rdfs:label "driveWheelConfiguration"@en ;
                                dc:source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group> ;
                                schema:rangeIncludes schema:DriveWheelConfigurationValue ,
                                                     schema:Text ;
-                               schema:domainIncludes schema:Vehicle ;
-                               rdfs:comment "The drive wheel configuration, i.e. which roadwheels will receive torque from the vehicle's engine via the drivetrain."@en .
+                               rdfs:comment "The drive wheel configuration, i.e. which roadwheels will receive torque from the vehicle's engine via the drivetrain."@en ;
+                               schema:domainIncludes schema:Vehicle .
 
 
 schema:dropoffLocation schema:rangeIncludes schema:Place ;
                        rdfs:comment "Where a rental car can be dropped off."@en ;
-                       rdfs:label "dropoffLocation"@en ;
-                       schema:domainIncludes schema:RentalCarReservation .
+                       schema:domainIncludes schema:RentalCarReservation ;
+                       rdfs:label "dropoffLocation"@en .
 
 
 schema:dropoffTime schema:domainIncludes schema:RentalCarReservation ;
@@ -9099,8 +9101,8 @@ schema:duringMedia schema:rangeIncludes schema:MediaObject ;
 
 
 schema:editor schema:domainIncludes schema:CreativeWork ;
-              rdfs:label "editor"@en ;
               schema:rangeIncludes schema:Person ;
+              rdfs:label "editor"@en ;
               rdfs:comment "Specifies the Person who edited the CreativeWork."@en .
 
 
@@ -9108,8 +9110,8 @@ schema:educationRequirements schema:rangeIncludes schema:Text ;
                              schema:domainIncludes schema:Occupation ,
                                                    schema:JobPosting ;
                              rdfs:comment "Educational background needed for the position or Occupation."@en ;
-                             rdfs:label "educationRequirements"@en ;
                              dc:source <https://github.com/schemaorg/schemaorg/issues/1698> ;
+                             rdfs:label "educationRequirements"@en ;
                              schema:category "issue-1698"@en .
 
 
@@ -9155,16 +9157,16 @@ schema:eligibleQuantity schema:rangeIncludes schema:QuantitativeValue ;
                         schema:domainIncludes schema:PriceSpecification ,
                                               schema:Demand ,
                                               schema:Offer ;
-                        rdfs:label "eligibleQuantity"@en ;
-                        rdfs:comment "The interval and unit of measurement of ordering quantities for which the offer or price specification is valid. This allows e.g. specifying that a certain freight charge is valid only for a certain quantity."@en .
+                        rdfs:comment "The interval and unit of measurement of ordering quantities for which the offer or price specification is valid. This allows e.g. specifying that a certain freight charge is valid only for a certain quantity."@en ;
+                        rdfs:label "eligibleQuantity"@en .
 
 
 schema:eligibleTransactionVolume schema:rangeIncludes schema:PriceSpecification ;
                                  schema:domainIncludes schema:PriceSpecification ,
-                                                       schema:Offer ,
-                                                       schema:Demand ;
+                                                       schema:Offer ;
+                                 rdfs:comment "The transaction volume, in a monetary unit, for which the offer or price specification is valid, e.g. for indicating a minimal purchasing volume, to express free shipping above a certain order volume, or to limit the acceptance of credit cards to purchases to a certain minimal amount."@en ;
                                  rdfs:label "eligibleTransactionVolume"@en ;
-                                 rdfs:comment "The transaction volume, in a monetary unit, for which the offer or price specification is valid, e.g. for indicating a minimal purchasing volume, to express free shipping above a certain order volume, or to limit the acceptance of credit cards to purchases to a certain minimal amount."@en .
+                                 schema:domainIncludes schema:Demand .
 
 
 schema:embedUrl schema:rangeIncludes schema:URL ;
@@ -9186,22 +9188,22 @@ schema:employees schema:rangeIncludes schema:Person ;
                  schema:domainIncludes schema:Organization .
 
 
-schema:employmentType rdfs:label "employmentType"@en ;
-                      schema:rangeIncludes schema:Text ;
+schema:employmentType schema:rangeIncludes schema:Text ;
+                      rdfs:label "employmentType"@en ;
                       schema:domainIncludes schema:JobPosting ;
                       rdfs:comment "Type of employment (e.g. full-time, part-time, contract, temporary, seasonal, internship)."@en .
 
 
 schema:encodesCreativeWork schema:rangeIncludes schema:CreativeWork ;
                            schema:domainIncludes schema:MediaObject ;
-                           rdfs:label "encodesCreativeWork"@en ;
                            schema:inverseOf schema:encoding ;
+                           rdfs:label "encodesCreativeWork"@en ;
                            rdfs:comment "The CreativeWork encoded by this media object."@en .
 
 
 schema:encoding schema:rangeIncludes schema:MediaObject ;
-                schema:domainIncludes schema:CreativeWork ;
                 rdfs:comment "A media object that encodes this CreativeWork. This property is a synonym for associatedMedia."@en ;
+                schema:domainIncludes schema:CreativeWork ;
                 rdfs:label "encoding"@en ;
                 schema:inverseOf schema:encodesCreativeWork .
 
@@ -9232,19 +9234,19 @@ schema:encodings schema:domainIncludes schema:CreativeWork ;
 
 
 schema:endTime rdfs:label "endTime"@en ;
-               schema:domainIncludes schema:Action ;
+               schema:domainIncludes schema:Action ,
+                                     schema:FoodEstablishmentReservation ;
                schema:rangeIncludes schema:Time ;
                rdfs:comment "The endTime of something. For a reserved event or service (e.g. FoodEstablishmentReservation), the time that it is expected to end. For actions that span a period of time, when the action was performed. e.g. John wrote a book from January to *December*. For media, including audio and video, it's the time offset of the end of a clip within a larger file.\\n\\nNote that Event uses startDate/endDate instead of startTime/endTime, even when describing dates with times. This situation may be clarified in future revisions."@en ;
-               schema:domainIncludes schema:FoodEstablishmentReservation ;
                schema:rangeIncludes schema:DateTime ;
                schema:domainIncludes schema:MediaObject .
 
 
 schema:episodes rdfs:comment "An episode of a TV/radio series or season."@en ;
-                schema:domainIncludes schema:VideoGameSeries ,
-                                      schema:TVSeries ;
+                schema:domainIncludes schema:VideoGameSeries ;
                 schema:rangeIncludes schema:Episode ;
-                schema:domainIncludes schema:CreativeWorkSeason ;
+                schema:domainIncludes schema:TVSeries ,
+                                      schema:CreativeWorkSeason ;
                 schema:supersededBy schema:episode ;
                 schema:domainIncludes schema:RadioSeries ;
                 rdfs:label "episodes"@en .
@@ -9282,8 +9284,8 @@ schema:estimatedSalary schema:domainIncludes schema:JobPosting ;
                        schema:rangeIncludes schema:MonetaryAmountDistribution ,
                                             schema:MonetaryAmount ;
                        rdfs:comment "An estimated salary for a job posting or occupation, based on a variety of variables including, but not limited to industry, job title, and location. Estimated salaries  are often computed by outside organizations rather than the hiring organization, who may not have committed to the estimated value."@en ;
-                       dc:source <https://github.com/schemaorg/schemaorg/issues/1698> ;
                        schema:category "issue-1698"@en ;
+                       dc:source <https://github.com/schemaorg/schemaorg/issues/1698> ;
                        schema:domainIncludes schema:Occupation ;
                        schema:rangeIncludes schema:Number .
 
@@ -9296,9 +9298,9 @@ schema:eventStatus rdfs:comment "An eventStatus of an event represents its statu
 
 schema:events rdfs:comment "Upcoming or past events associated with this place or organization."@en ;
               schema:supersededBy schema:event ;
+              schema:domainIncludes schema:Place ;
               rdfs:label "events"@en ;
-              schema:domainIncludes schema:Place ,
-                                    schema:Organization ;
+              schema:domainIncludes schema:Organization ;
               schema:rangeIncludes schema:Event .
 
 
@@ -9306,8 +9308,8 @@ schema:exampleOfWork rdfs:comment "A creative work that this work is an example/
                      dc:source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex> ;
                      schema:domainIncludes schema:CreativeWork ;
                      schema:rangeIncludes schema:CreativeWork ;
-                     rdfs:label "exampleOfWork"@en ;
-                     schema:inverseOf schema:workExample .
+                     schema:inverseOf schema:workExample ;
+                     rdfs:label "exampleOfWork"@en .
 
 
 schema:executableLibraryName rdfs:label "executableLibraryName"@en ;
@@ -9316,8 +9318,8 @@ schema:executableLibraryName rdfs:label "executableLibraryName"@en ;
                              schema:rangeIncludes schema:Text .
 
 
-schema:exifData schema:rangeIncludes schema:PropertyValue ;
-                schema:domainIncludes schema:ImageObject ;
+schema:exifData schema:domainIncludes schema:ImageObject ;
+                schema:rangeIncludes schema:PropertyValue ;
                 rdfs:label "exifData"@en ;
                 rdfs:comment "exif data for this object."@en ;
                 schema:rangeIncludes schema:Text .
@@ -9340,9 +9342,9 @@ schema:expectedArrivalUntil rdfs:comment "The latest date the package may arrive
 schema:expectsAcceptanceOf schema:domainIncludes schema:ConsumeAction ;
                            schema:category "issue-1741"@en ;
                            schema:rangeIncludes schema:Offer ;
-                           schema:domainIncludes schema:ActionAccessSpecification ,
-                                                 schema:MediaSubscription ;
                            rdfs:comment "An Offer which must be accepted before the user can perform the Action. For example, the user may need to buy a movie before being able to watch it."@en ;
+                           schema:domainIncludes schema:MediaSubscription ,
+                                                 schema:ActionAccessSpecification ;
                            rdfs:label "expectsAcceptanceOf"@en ;
                            dc:source <https://github.com/schemaorg/schemaorg/issues/1741> .
 
@@ -9358,8 +9360,8 @@ schema:experienceRequirements schema:domainIncludes schema:JobPosting ;
 
 schema:expires schema:rangeIncludes schema:Date ;
                rdfs:label "expires"@en ;
-               schema:domainIncludes schema:CreativeWork ;
-               rdfs:comment "Date the content expires and is no longer useful or available. For example a [[VideoObject]] or [[NewsArticle]] whose availability or relevance is time-limited, or a [[ClaimReview]] fact check whose publisher wants to indicate that it may no longer be relevant (or helpful to highlight) after some date."@en .
+               rdfs:comment "Date the content expires and is no longer useful or available. For example a [[VideoObject]] or [[NewsArticle]] whose availability or relevance is time-limited, or a [[ClaimReview]] fact check whose publisher wants to indicate that it may no longer be relevant (or helpful to highlight) after some date."@en ;
+               schema:domainIncludes schema:CreativeWork .
 
 
 schema:fatContent schema:rangeIncludes schema:Mass ;
@@ -9413,9 +9415,9 @@ schema:firstPerformance rdfs:comment "The date and place the work was first perf
 
 schema:flightDistance rdfs:label "flightDistance"@en ;
                       rdfs:comment "The distance of the flight."@en ;
-                      schema:rangeIncludes schema:Distance ,
-                                           schema:Text ;
-                      schema:domainIncludes schema:Flight .
+                      schema:rangeIncludes schema:Distance ;
+                      schema:domainIncludes schema:Flight ;
+                      schema:rangeIncludes schema:Text .
 
 
 schema:floorSize schema:domainIncludes schema:Accommodation ;
@@ -9428,8 +9430,8 @@ Typical unit code(s): MTK for square meter, FTK for square foot, or YDK for squa
 
 schema:follows schema:rangeIncludes schema:Person ;
                rdfs:comment "The most generic uni-directional social relation."@en ;
-               schema:domainIncludes schema:Person ;
-               rdfs:label "follows"@en .
+               rdfs:label "follows"@en ;
+               schema:domainIncludes schema:Person .
 
 
 schema:founder schema:rangeIncludes schema:Person ;
@@ -9451,8 +9453,8 @@ schema:foundingDate schema:rangeIncludes schema:Date ;
                     schema:domainIncludes schema:Organization .
 
 
-schema:foundingLocation schema:domainIncludes schema:Organization ;
-                        schema:rangeIncludes schema:Place ;
+schema:foundingLocation schema:rangeIncludes schema:Place ;
+                        schema:domainIncludes schema:Organization ;
                         rdfs:label "foundingLocation"@en ;
                         rdfs:comment "The place where the Organization was founded."@en .
 
@@ -9465,8 +9467,8 @@ schema:free schema:domainIncludes schema:PublicationEvent ;
 
 
 schema:fuelConsumption schema:domainIncludes schema:Vehicle ;
-                       dc:source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group> ;
                        rdfs:label "fuelConsumption"@en ;
+                       dc:source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group> ;
                        schema:rangeIncludes schema:QuantitativeValue ;
                        rdfs:comment "The amount of fuel consumed for traveling a particular distance or temporal duration with the given vehicle (e.g. liters per 100 km).\\n\\n* Note 1: There are unfortunately no standard unit codes for liters per 100 km.  Use [[unitText]] to indicate the unit of measurement, e.g. L/100 km.\\n* Note 2: There are two ways of indicating the fuel consumption, [[fuelConsumption]] (e.g. 8 liters per 100 km) and [[fuelEfficiency]] (e.g. 30 miles per gallon). They are reciprocal.\\n* Note 3: Often, the absolute value is useful only when related to driving speed (\"at 80 km/h\") or usage pattern (\"city traffic\"). You can use [[valueReference]] to link the value for the fuel consumption to another value."@en .
 
@@ -9511,24 +9513,24 @@ schema:gameLocation schema:domainIncludes schema:VideoGameSeries ;
                     rdfs:comment "Real or fictional location of the game (or part of game)."@en .
 
 
-schema:gamePlatform rdfs:comment "The electronic systems used to play <a href=\"http://en.wikipedia.org/wiki/Category:Video_game_platforms\">video games</a>."@en ;
+schema:gamePlatform schema:rangeIncludes schema:Text ;
                     schema:domainIncludes schema:VideoGameSeries ;
-                    schema:rangeIncludes schema:Text ,
-                                         schema:URL ;
+                    rdfs:comment "The electronic systems used to play <a href=\"http://en.wikipedia.org/wiki/Category:Video_game_platforms\">video games</a>."@en ;
+                    schema:rangeIncludes schema:URL ;
                     rdfs:label "gamePlatform"@en ;
                     schema:domainIncludes schema:VideoGame ;
                     schema:rangeIncludes schema:Thing .
 
 
-schema:gameServer schema:domainIncludes schema:VideoGame ;
-                  schema:rangeIncludes schema:GameServer ;
+schema:gameServer schema:rangeIncludes schema:GameServer ;
+                  schema:domainIncludes schema:VideoGame ;
                   schema:inverseOf schema:game ;
                   rdfs:comment "The server on which  it is possible to play the game."@en ;
                   rdfs:label "gameServer"@en .
 
 
-schema:gameTip rdfs:label "gameTip"@en ;
-               rdfs:comment "Links to tips, tactics, etc."@en ;
+schema:gameTip rdfs:comment "Links to tips, tactics, etc."@en ;
+               rdfs:label "gameTip"@en ;
                schema:domainIncludes schema:VideoGame ;
                schema:rangeIncludes schema:CreativeWork .
 
@@ -9542,8 +9544,8 @@ schema:gender rdfs:comment "Gender of the person. While http://schema.org/Male a
 
 schema:genre rdfs:label "genre"@en ;
              schema:rangeIncludes schema:Text ;
-             schema:domainIncludes schema:CreativeWork ,
-                                   schema:MusicGroup ;
+             schema:domainIncludes schema:MusicGroup ,
+                                   schema:CreativeWork ;
              schema:rangeIncludes schema:URL ;
              schema:domainIncludes schema:BroadcastChannel ;
              rdfs:comment "Genre of the creative work, broadcast channel or group."@en .
@@ -9590,8 +9592,8 @@ schema:greaterOrEqual rdfs:comment "This ordering relation for qualitative value
                       schema:domainIncludes schema:QualitativeValue .
 
 
-schema:hasBroadcastChannel schema:rangeIncludes schema:BroadcastChannel ;
-                           schema:category "issue-1004"@en ;
+schema:hasBroadcastChannel schema:category "issue-1004"@en ;
+                           schema:rangeIncludes schema:BroadcastChannel ;
                            dc:source <https://github.com/schemaorg/schemaorg/issues/1004> ;
                            rdfs:comment "A broadcast channel of a broadcast service."@en ;
                            rdfs:label "hasBroadcastChannel"@en ;
@@ -9662,9 +9664,9 @@ schema:headline rdfs:comment "Headline of the article."@en ;
 
 
 schema:height schema:domainIncludes schema:Person ,
-                                    schema:Product ,
                                     schema:MediaObject ,
-                                    schema:VisualArtwork ;
+                                    schema:VisualArtwork ,
+                                    schema:Product ;
               rdfs:label "height"@en ;
               schema:rangeIncludes schema:Distance ,
                                    schema:QuantitativeValue ;
@@ -9672,14 +9674,14 @@ schema:height schema:domainIncludes schema:Person ,
 
 
 schema:highPrice schema:domainIncludes schema:AggregateOffer ;
-                 schema:rangeIncludes schema:Text ;
                  rdfs:comment "The highest price of all offers available.\\n\\nUsage guidelines:\\n\\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similiar Unicode symbols.\\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator."@en ;
+                 schema:rangeIncludes schema:Text ;
                  rdfs:label "highPrice"@en ;
                  schema:rangeIncludes schema:Number .
 
 
-schema:hiringOrganization schema:rangeIncludes schema:Organization ;
-                          rdfs:comment "Organization offering the job position."@en ;
+schema:hiringOrganization rdfs:comment "Organization offering the job position."@en ;
+                          schema:rangeIncludes schema:Organization ;
                           rdfs:label "hiringOrganization"@en ;
                           schema:domainIncludes schema:JobPosting .
 
@@ -9705,9 +9707,9 @@ schema:hostingOrganization rdfs:comment "The organization (airline, travelers' c
 schema:hoursAvailable schema:domainIncludes schema:ContactPoint ;
                       schema:rangeIncludes schema:OpeningHoursSpecification ;
                       rdfs:comment "The hours during which this service or contact is available."@en ;
-                      schema:domainIncludes schema:Service ;
                       rdfs:label "hoursAvailable"@en ;
-                      schema:domainIncludes schema:LocationFeatureSpecification .
+                      schema:domainIncludes schema:Service ,
+                                            schema:LocationFeatureSpecification .
 
 
 schema:httpMethod rdfs:comment "An HTTP method that specifies the appropriate HTTP method for a request to an HTTP EntryPoint. Values are capitalized strings as used in HTTP."@en ;
@@ -9735,6 +9737,13 @@ schema:illustrator rdfs:comment "The illustrator of the book."@en ;
                    schema:rangeIncludes schema:Person .
 
 
+schema:image schema:domainIncludes schema:Thing ;
+             rdfs:comment "An image of the item. This can be a [[URL]] or a fully described [[ImageObject]]."@en ;
+             schema:rangeIncludes schema:URL ,
+                                  schema:ImageObject ;
+             rdfs:label "image"@en .
+
+
 schema:inAlbum rdfs:comment "The album to which this recording belongs."@en ;
                rdfs:label "inAlbum"@en ;
                schema:rangeIncludes schema:MusicAlbum ;
@@ -9757,8 +9766,8 @@ schema:inLanguage rdfs:comment "The language of the content or performance or us
                                         schema:CommunicateAction .
 
 
-schema:inPlaylist schema:domainIncludes schema:MusicRecording ;
-                  rdfs:label "inPlaylist"@en ;
+schema:inPlaylist rdfs:label "inPlaylist"@en ;
+                  schema:domainIncludes schema:MusicRecording ;
                   schema:rangeIncludes schema:MusicPlaylist ;
                   rdfs:comment "The playlist to which this recording belongs."@en .
 
@@ -9792,8 +9801,8 @@ schema:includedDataCatalog rdfs:comment "A data catalog which contains this data
 
 schema:includedInDataCatalog schema:rangeIncludes schema:DataCatalog ;
                              rdfs:comment "A data catalog which contains this dataset."@en ;
-                             rdfs:label "includedInDataCatalog"@en ;
                              schema:domainIncludes schema:Dataset ;
+                             rdfs:label "includedInDataCatalog"@en ;
                              schema:inverseOf schema:dataset .
 
 
@@ -9810,12 +9819,12 @@ schema:industry schema:rangeIncludes schema:Text ;
                 rdfs:comment "The industry associated with the job position."@en .
 
 
-schema:ineligibleRegion rdfs:label "ineligibleRegion"@en ;
-                        schema:rangeIncludes schema:Text ,
-                                             schema:Place ,
-                                             schema:GeoShape ;
-                        schema:domainIncludes schema:Demand ,
-                                              schema:Offer ;
+schema:ineligibleRegion schema:rangeIncludes schema:Text ;
+                        rdfs:label "ineligibleRegion"@en ;
+                        schema:rangeIncludes schema:Place ;
+                        schema:domainIncludes schema:Demand ;
+                        schema:rangeIncludes schema:GeoShape ;
+                        schema:domainIncludes schema:Offer ;
                         rdfs:comment """The ISO 3166-1 (ISO 3166-1 alpha-2) or ISO 3166-2 code, the place, or the GeoShape for the geo-political region(s) for which the offer or delivery charge specification is not valid, e.g. a region where the transaction is not allowed.\\n\\nSee also [[eligibleRegion]].
       """@en ;
                         schema:domainIncludes schema:DeliveryChargeSpecification .
@@ -9894,11 +9903,11 @@ schema:isAccessoryOrSparePartFor schema:rangeIncludes schema:Product ;
                                  schema:domainIncludes schema:Product .
 
 
-schema:isBasedOn schema:domainIncludes schema:CreativeWork ;
-                 schema:rangeIncludes schema:URL ,
-                                      schema:Product ;
-                 rdfs:comment "A resource from which this work is derived or from which it is a modification or adaption."@en ;
+schema:isBasedOn schema:rangeIncludes schema:URL ;
+                 schema:domainIncludes schema:CreativeWork ;
+                 schema:rangeIncludes schema:Product ;
                  rdfs:label "isBasedOn"@en ;
+                 rdfs:comment "A resource from which this work is derived or from which it is a modification or adaption."@en ;
                  schema:rangeIncludes schema:CreativeWork .
 
 
@@ -9918,8 +9927,8 @@ schema:isConsumableFor schema:domainIncludes schema:Product ;
 
 
 schema:isFamilyFriendly rdfs:comment "Indicates whether this content is family friendly."@en ;
-                        schema:domainIncludes schema:CreativeWork ;
                         schema:rangeIncludes schema:Boolean ;
+                        schema:domainIncludes schema:CreativeWork ;
                         rdfs:label "isFamilyFriendly"@en .
 
 
@@ -9958,11 +9967,11 @@ schema:isVariantOf schema:rangeIncludes schema:ProductModel ;
 
 
 schema:isicV4 schema:rangeIncludes schema:Text ;
-              schema:domainIncludes schema:Place ;
               rdfs:comment "The International Standard of Industrial Classification of All Economic Activities (ISIC), Revision 4 code for a particular organization, business person, or place."@en ;
-              schema:domainIncludes schema:Organization ,
-                                    schema:Person ;
-              rdfs:label "isicV4"@en .
+              schema:domainIncludes schema:Place ,
+                                    schema:Organization ;
+              rdfs:label "isicV4"@en ;
+              schema:domainIncludes schema:Person .
 
 
 schema:isrcCode rdfs:comment "The International Standard Recording Code for the recording."@en ;
@@ -9975,8 +9984,8 @@ schema:isrcCode rdfs:comment "The International Standard Recording Code for the 
 schema:issuedBy rdfs:label "issuedBy"@en ;
                 schema:domainIncludes schema:Permit ;
                 rdfs:comment "The organization issuing the ticket or permit."@en ;
-                schema:domainIncludes schema:Ticket ;
-                schema:rangeIncludes schema:Organization .
+                schema:rangeIncludes schema:Organization ;
+                schema:domainIncludes schema:Ticket .
 
 
 schema:issuedThrough rdfs:label "issuedThrough"@en ;
@@ -9985,8 +9994,8 @@ schema:issuedThrough rdfs:label "issuedThrough"@en ;
                      schema:rangeIncludes schema:Service .
 
 
-schema:iswcCode rdfs:label "iswcCode"@en ;
-                schema:rangeIncludes schema:Text ;
+schema:iswcCode schema:rangeIncludes schema:Text ;
+                rdfs:label "iswcCode"@en ;
                 rdfs:comment "The International Standard Musical Work Code for the composition."@en ;
                 dc:source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#MBZ> ;
                 schema:domainIncludes schema:MusicComposition .
@@ -10007,10 +10016,10 @@ schema:itemCondition schema:rangeIncludes schema:OfferItemCondition ;
                      rdfs:comment "A predefined value from OfferItemCondition or a textual description of the condition of the product or service, or the products or services included in the offer."@en .
 
 
-schema:itemListElement schema:rangeIncludes schema:Text ,
-                                            schema:Thing ;
+schema:itemListElement schema:rangeIncludes schema:Text ;
                        schema:domainIncludes schema:ItemList ;
-                       schema:rangeIncludes schema:ListItem ;
+                       schema:rangeIncludes schema:Thing ,
+                                            schema:ListItem ;
                        rdfs:label "itemListElement"@en ;
                        rdfs:comment "For itemListElement values, you can use simple strings (e.g. \"Peter\", \"Paul\", \"Mary\"), existing entities, or use ListItem.\\n\\nText values are best if the elements in the list are plain strings. Existing entities are best for a simple, unordered list of existing things in your data. ListItem is used with ordered lists when you want to provide additional context about the element in that list or when the same item might be in different places in different lists.\\n\\nNote: The order of elements in your mark-up is not sufficient for indicating the order or elements.  Use ListItem with a 'position' property in such cases."@en .
 
@@ -10142,17 +10151,17 @@ schema:lodgingUnitDescription schema:domainIncludes schema:LodgingReservation ;
 
 
 schema:lodgingUnitType schema:rangeIncludes schema:QualitativeValue ;
-                       schema:domainIncludes schema:LodgingReservation ;
                        rdfs:comment "Textual description of the unit type (including suite vs. room, size of bed, etc.)."@en ;
+                       schema:domainIncludes schema:LodgingReservation ;
                        schema:rangeIncludes schema:Text ;
                        rdfs:label "lodgingUnitType"@en .
 
 
-schema:lowPrice rdfs:comment "The lowest price of all offers available.\\n\\nUsage guidelines:\\n\\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similiar Unicode symbols.\\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator."@en ;
-                schema:domainIncludes schema:AggregateOffer ;
+schema:lowPrice schema:domainIncludes schema:AggregateOffer ;
+                rdfs:comment "The lowest price of all offers available.\\n\\nUsage guidelines:\\n\\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similiar Unicode symbols.\\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator."@en ;
                 rdfs:label "lowPrice"@en ;
-                schema:rangeIncludes schema:Number ,
-                                     schema:Text .
+                schema:rangeIncludes schema:Text ,
+                                     schema:Number .
 
 
 schema:lyricist rdfs:comment "The person who wrote the words."@en ;
@@ -10186,9 +10195,9 @@ schema:mainEntityOfPage rdfs:label "mainEntityOfPage"@en ;
 schema:makesOffer schema:inverseOf schema:offeredBy ;
                   rdfs:comment "A pointer to products or services offered by the organization or person."@en ;
                   rdfs:label "makesOffer"@en ;
-                  schema:domainIncludes schema:Organization ;
                   schema:rangeIncludes schema:Offer ;
-                  schema:domainIncludes schema:Person .
+                  schema:domainIncludes schema:Organization ,
+                                        schema:Person .
 
 
 schema:manufacturer schema:domainIncludes schema:Product ;
@@ -10198,8 +10207,8 @@ schema:manufacturer schema:domainIncludes schema:Product ;
 
 
 schema:map schema:supersededBy schema:hasMap ;
-           schema:rangeIncludes schema:URL ;
            schema:domainIncludes schema:Place ;
+           schema:rangeIncludes schema:URL ;
            rdfs:label "map"@en ;
            rdfs:comment "A URL to a map of the place."@en .
 
@@ -10210,8 +10219,8 @@ schema:mapType rdfs:label "mapType"@en ;
                rdfs:comment "Indicates the kind of Map, from the MapCategoryType Enumeration."@en .
 
 
-schema:maps rdfs:comment "A URL to a map of the place."@en ;
-            schema:rangeIncludes schema:URL ;
+schema:maps schema:rangeIncludes schema:URL ;
+            rdfs:comment "A URL to a map of the place."@en ;
             schema:supersededBy schema:hasMap ;
             schema:domainIncludes schema:Place ;
             rdfs:label "maps"@en .
@@ -10238,10 +10247,10 @@ schema:mealService schema:rangeIncludes schema:Text ;
 
 schema:median rdfs:label "median"@en ;
               rdfs:comment "The median value."@en ;
-              dc:source <https://github.com/schemaorg/schemaorg/issues/1698> ;
               schema:rangeIncludes schema:Number ;
-              schema:category "issue-1698"@en ;
-              schema:domainIncludes schema:QuantitativeValueDistribution .
+              dc:source <https://github.com/schemaorg/schemaorg/issues/1698> ;
+              schema:domainIncludes schema:QuantitativeValueDistribution ;
+              schema:category "issue-1698"@en .
 
 
 schema:member schema:rangeIncludes schema:Person ,
@@ -10268,8 +10277,8 @@ schema:membershipNumber rdfs:comment "A unique identifier for the membership."@e
                         schema:rangeIncludes schema:Text .
 
 
-schema:memoryRequirements schema:rangeIncludes schema:URL ;
-                          schema:domainIncludes schema:SoftwareApplication ;
+schema:memoryRequirements schema:domainIncludes schema:SoftwareApplication ;
+                          schema:rangeIncludes schema:URL ;
                           rdfs:label "memoryRequirements"@en ;
                           schema:rangeIncludes schema:Text ;
                           rdfs:comment "Minimum memory requirements."@en .
@@ -10293,18 +10302,18 @@ schema:menu schema:rangeIncludes schema:URL ;
 schema:menuAddOn schema:domainIncludes schema:MenuItem ;
                  rdfs:label "menuAddOn"@en ;
                  dc:source <https://github.com/schemaorg/schemaorg/issues/1541> ;
+                 schema:rangeIncludes schema:MenuSection ;
                  schema:category "issue-1541"@en ;
-                 schema:rangeIncludes schema:MenuSection ,
-                                      schema:MenuItem ;
+                 schema:rangeIncludes schema:MenuItem ;
                  rdfs:comment "Additional menu item(s) such as a side dish of salad or side order of fries that can be added to this menu item. Additionally it can be a menu section containing allowed add-on menu items for this menu item."@en .
 
 
 schema:merchant rdfs:comment "'merchant' is an out-dated term for 'seller'."@en ;
                 rdfs:label "merchant"@en ;
                 schema:domainIncludes schema:Order ;
-                schema:rangeIncludes schema:Organization ;
-                schema:supersededBy schema:seller ;
-                schema:rangeIncludes schema:Person .
+                schema:rangeIncludes schema:Organization ,
+                                     schema:Person ;
+                schema:supersededBy schema:seller .
 
 
 schema:messageAttachment rdfs:comment "A CreativeWork attached to the message."@en ;
@@ -10333,11 +10342,11 @@ schema:minimumPaymentDue rdfs:comment "The minimum payment required at this time
                          schema:domainIncludes schema:Invoice .
 
 
-schema:model rdfs:label "model"@en ;
-             schema:rangeIncludes schema:ProductModel ;
+schema:model schema:rangeIncludes schema:ProductModel ;
+             rdfs:label "model"@en ;
              rdfs:comment "The model of the product. Use with the URL of a ProductModel or a textual representation of the model identifier. The URL of the ProductModel can be from an external source. It is recommended to additionally provide strong product identifiers via the gtin8/gtin13/gtin14 and mpn properties."@en ;
-             schema:domainIncludes schema:Product ;
-             schema:rangeIncludes schema:Text .
+             schema:rangeIncludes schema:Text ;
+             schema:domainIncludes schema:Product .
 
 
 schema:modifiedTime schema:domainIncludes schema:Reservation ;
@@ -10383,15 +10392,15 @@ schema:musicBy schema:domainIncludes schema:VideoGame ;
 
 
 schema:musicCompositionForm dc:source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#MBZ> ;
-                            rdfs:comment "The type of composition (e.g. overture, sonata, symphony, etc.)."@en ;
                             schema:domainIncludes schema:MusicComposition ;
+                            rdfs:comment "The type of composition (e.g. overture, sonata, symphony, etc.)."@en ;
                             rdfs:label "musicCompositionForm"@en ;
                             schema:rangeIncludes schema:Text .
 
 
 schema:musicGroupMember schema:supersededBy schema:member ;
-                        schema:domainIncludes schema:MusicGroup ;
                         rdfs:label "musicGroupMember"@en ;
+                        schema:domainIncludes schema:MusicGroup ;
                         schema:rangeIncludes schema:Person ;
                         rdfs:comment "A member of a music group&#x2014;for example, John, Paul, George, or Ringo."@en .
 
@@ -10425,16 +10434,16 @@ schema:name schema:domainIncludes schema:Thing ;
 
 schema:namedPosition schema:domainIncludes schema:Role ;
                      rdfs:comment "A position played, performed or filled by a person or organization, as part of an organization. For example, an athlete in a SportsTeam might play in the position named 'Quarterback'."@en ;
-                     schema:rangeIncludes schema:Text ,
-                                          schema:URL ;
+                     schema:rangeIncludes schema:Text ;
                      schema:supersededBy schema:roleName ;
+                     schema:rangeIncludes schema:URL ;
                      rdfs:label "namedPosition"@en .
 
 
 schema:nationality rdfs:comment "Nationality of the person."@en ;
                    schema:domainIncludes schema:Person ;
-                   schema:rangeIncludes schema:Country ;
-                   rdfs:label "nationality"@en .
+                   rdfs:label "nationality"@en ;
+                   schema:rangeIncludes schema:Country .
 
 
 schema:netWorth schema:rangeIncludes schema:MonetaryAmount ;
@@ -10459,8 +10468,8 @@ schema:nonEqual rdfs:comment "This ordering relation for qualitative values indi
 schema:numAdults schema:rangeIncludes schema:QuantitativeValue ;
                  rdfs:comment "The number of adults staying in the unit."@en ;
                  rdfs:label "numAdults"@en ;
-                 schema:rangeIncludes schema:Integer ;
-                 schema:domainIncludes schema:LodgingReservation .
+                 schema:domainIncludes schema:LodgingReservation ;
+                 schema:rangeIncludes schema:Integer .
 
 
 schema:numChildren schema:rangeIncludes schema:Integer ;
@@ -10476,17 +10485,17 @@ schema:numTracks schema:domainIncludes schema:MusicPlaylist ;
                  schema:rangeIncludes schema:Integer .
 
 
-schema:numberOfAirbags schema:rangeIncludes schema:Text ,
-                                            schema:Number ;
+schema:numberOfAirbags schema:rangeIncludes schema:Number ,
+                                            schema:Text ;
                        schema:domainIncludes schema:Vehicle ;
                        rdfs:comment "The number or type of airbags in the vehicle."@en ;
-                       rdfs:label "numberOfAirbags"@en ;
-                       dc:source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group> .
+                       dc:source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group> ;
+                       rdfs:label "numberOfAirbags"@en .
 
 
-schema:numberOfAxles dc:source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group> ;
+schema:numberOfAxles rdfs:comment "The number of axles.\\n\\nTypical unit code(s): C62"@en ;
                      schema:rangeIncludes schema:QuantitativeValue ;
-                     rdfs:comment "The number of axles.\\n\\nTypical unit code(s): C62"@en ;
+                     dc:source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group> ;
                      schema:rangeIncludes schema:Number ;
                      rdfs:label "numberOfAxles"@en ;
                      schema:domainIncludes schema:Vehicle .
@@ -10508,15 +10517,15 @@ schema:numberOfDoors schema:rangeIncludes schema:Number ;
 
 
 schema:numberOfEmployees schema:rangeIncludes schema:QuantitativeValue ;
-                         schema:domainIncludes schema:BusinessAudience ;
                          rdfs:label "numberOfEmployees"@en ;
+                         schema:domainIncludes schema:BusinessAudience ;
                          rdfs:comment "The number of employees in an organization e.g. business."@en ;
                          schema:domainIncludes schema:Organization .
 
 
 schema:numberOfEpisodes schema:domainIncludes schema:CreativeWorkSeason ,
-                                              schema:RadioSeries ,
                                               schema:VideoGameSeries ,
+                                              schema:RadioSeries ,
                                               schema:TVSeries ;
                         schema:rangeIncludes schema:Integer ;
                         rdfs:label "numberOfEpisodes"@en ;
@@ -10553,21 +10562,21 @@ schema:numberOfPlayers schema:domainIncludes schema:Game ;
 schema:numberOfPreviousOwners schema:rangeIncludes schema:Number ;
                               schema:domainIncludes schema:Vehicle ;
                               schema:rangeIncludes schema:QuantitativeValue ;
-                              rdfs:comment "The number of owners of the vehicle, including the current one.\\n\\nTypical unit code(s): C62"@en ;
                               rdfs:label "numberOfPreviousOwners"@en ;
+                              rdfs:comment "The number of owners of the vehicle, including the current one.\\n\\nTypical unit code(s): C62"@en ;
                               dc:source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group> .
 
 
 schema:numberOfRooms schema:domainIncludes schema:SingleFamilyResidence ;
                      schema:rangeIncludes schema:QuantitativeValue ;
-                     schema:domainIncludes schema:LodgingBusiness ;
+                     schema:domainIncludes schema:LodgingBusiness ,
+                                           schema:Suite ;
                      rdfs:label "numberOfRooms"@en ;
-                     schema:domainIncludes schema:Suite ,
-                                           schema:House ,
-                                           schema:Apartment ,
-                                           schema:Accommodation ;
+                     schema:domainIncludes schema:House ,
+                                           schema:Apartment ;
                      rdfs:comment """The number of rooms (excluding bathrooms and closets) of the accommodation or lodging business.
 Typical unit code(s): ROM for room or C62 for no unit. The type of room can be put in the unitText property of the QuantitativeValue."""@en ;
+                     schema:domainIncludes schema:Accommodation ;
                      dc:source <https://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#STI_Accommodation_Ontology> ;
                      schema:rangeIncludes schema:Number .
 
@@ -10601,12 +10610,12 @@ schema:occupationLocation rdfs:label "occupationLocation"@en ;
                           rdfs:comment " The region/country for which this occupational description is appropriate. Note that educational requirements and qualifications can vary between jurisdictions."@en .
 
 
-schema:occupationalCategory schema:domainIncludes schema:JobPosting ,
-                                                  schema:Occupation ;
-                            rdfs:comment """A category describing the job, preferably using a term from a taxonomy such as [BLS O*NET-SOC](http://www.onetcenter.org/taxonomy.html), [ISCO-08](https://www.ilo.org/public/english/bureau/stat/isco/isco08/) or similar, with the property repeated for each applicable value. Ideally the taxonomy should be identified, and both the textual label and formal code for the category should be provided.\\n
-Note: for historical reasons, any textual label and formal code provided as a literal may be assumed to be from O*NET-SOC."""@en ;
+schema:occupationalCategory schema:domainIncludes schema:Occupation ,
+                                                  schema:JobPosting ;
                             rdfs:label "occupationalCategory"@en ;
                             schema:rangeIncludes schema:Text ;
+                            rdfs:comment """A category describing the job, preferably using a term from a taxonomy such as [BLS O*NET-SOC](http://www.onetcenter.org/taxonomy.html), [ISCO-08](https://www.ilo.org/public/english/bureau/stat/isco/isco08/) or similar, with the property repeated for each applicable value. Ideally the taxonomy should be identified, and both the textual label and formal code for the category should be provided.\\n
+Note: for historical reasons, any textual label and formal code provided as a literal may be assumed to be from O*NET-SOC."""@en ;
                             schema:category "issue-1698"@en ;
                             dc:source <https://github.com/schemaorg/schemaorg/issues/1698> .
 
@@ -10627,9 +10636,9 @@ schema:offeredBy schema:domainIncludes schema:Offer ;
 
 schema:offers schema:domainIncludes schema:AggregateOffer ;
               rdfs:comment "An offer to provide this item&#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event."@en ;
-              schema:domainIncludes schema:Product ,
-                                    schema:Event ;
+              schema:domainIncludes schema:Product ;
               rdfs:label "offers"@en ;
+              schema:domainIncludes schema:Event ;
               schema:rangeIncludes schema:Offer ;
               schema:domainIncludes schema:CreativeWork ,
                                     schema:Trip ,
@@ -10637,8 +10646,8 @@ schema:offers schema:domainIncludes schema:AggregateOffer ;
                                     schema:Service .
 
 
-schema:openingHours schema:domainIncludes schema:CivicStructure ,
-                                          schema:LocalBusiness ;
+schema:openingHours schema:domainIncludes schema:LocalBusiness ,
+                                          schema:CivicStructure ;
                     rdfs:comment "The general opening hours for a business. Opening hours can be specified as a weekly time range, starting with days, then times per day. Multiple days can be listed with commas ',' separating each day. Day or time ranges are specified using a hyphen '-'.\\n\\n* Days are specified using the following two-letter combinations: ```Mo```, ```Tu```, ```We```, ```Th```, ```Fr```, ```Sa```, ```Su```.\\n* Times are specified using 24:00 time. For example, 3pm is specified as ```15:00```. \\n* Here is an example: <code>&lt;time itemprop=\"openingHours\" datetime=&quot;Tu,Th 16:00-20:00&quot;&gt;Tuesdays and Thursdays 4-8pm&lt;/time&gt;</code>.\\n* If a business is open 7 days a week, then it can be specified as <code>&lt;time itemprop=&quot;openingHours&quot; datetime=&quot;Mo-Su&quot;&gt;Monday through Sunday, all day&lt;/time&gt;</code>."@en ;
                     schema:rangeIncludes schema:Text ;
                     rdfs:label "openingHours"@en .
@@ -10656,14 +10665,14 @@ schema:opens rdfs:comment "The opening hour of the place or service on the given
              schema:rangeIncludes schema:Time .
 
 
-schema:operatingSystem schema:domainIncludes schema:SoftwareApplication ;
-                       schema:rangeIncludes schema:Text ;
+schema:operatingSystem schema:rangeIncludes schema:Text ;
+                       schema:domainIncludes schema:SoftwareApplication ;
                        rdfs:label "operatingSystem"@en ;
                        rdfs:comment "Operating systems supported (Windows 7, OSX 10.6, Android 1.6)."@en .
 
 
-schema:orderDate schema:rangeIncludes schema:DateTime ;
-                 rdfs:comment "Date order was placed."@en ;
+schema:orderDate rdfs:comment "Date order was placed."@en ;
+                 schema:rangeIncludes schema:DateTime ;
                  rdfs:label "orderDate"@en ;
                  schema:domainIncludes schema:Order ;
                  schema:rangeIncludes schema:Date .
@@ -10677,8 +10686,8 @@ schema:orderDelivery schema:domainIncludes schema:Order ;
 
 
 schema:orderItemNumber schema:domainIncludes schema:OrderItem ;
-                       rdfs:comment "The identifier of the order item."@en ;
                        schema:rangeIncludes schema:Text ;
+                       rdfs:comment "The identifier of the order item."@en ;
                        rdfs:label "orderItemNumber"@en .
 
 
@@ -10723,13 +10732,13 @@ schema:ownedFrom schema:rangeIncludes schema:DateTime ;
 
 schema:ownedThrough schema:domainIncludes schema:OwnershipInfo ;
                     rdfs:label "ownedThrough"@en ;
-                    schema:rangeIncludes schema:DateTime ;
-                    rdfs:comment "The date and time of giving up ownership on the product."@en .
+                    rdfs:comment "The date and time of giving up ownership on the product."@en ;
+                    schema:rangeIncludes schema:DateTime .
 
 
-schema:owns schema:rangeIncludes schema:Product ;
+schema:owns schema:rangeIncludes schema:Product ,
+                                 schema:OwnershipInfo ;
             schema:domainIncludes schema:Organization ;
-            schema:rangeIncludes schema:OwnershipInfo ;
             rdfs:comment "Products owned by the organization or person."@en ;
             rdfs:label "owns"@en ;
             schema:domainIncludes schema:Person .
@@ -10764,8 +10773,8 @@ schema:pagination dc:source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSourc
                   schema:domainIncludes schema:PublicationVolume .
 
 
-schema:parent rdfs:label "parent"@en ;
-              schema:domainIncludes schema:Person ;
+schema:parent schema:domainIncludes schema:Person ;
+              rdfs:label "parent"@en ;
               schema:rangeIncludes schema:Person ;
               rdfs:comment "A parent of this person."@en .
 
@@ -10791,8 +10800,8 @@ schema:parentService rdfs:comment "A broadcast service to which the broadcast se
 
 schema:parents schema:domainIncludes schema:Person ;
                schema:rangeIncludes schema:Person ;
-               rdfs:comment "A parents of the person."@en ;
                schema:supersededBy schema:parent ;
+               rdfs:comment "A parents of the person."@en ;
                rdfs:label "parents"@en .
 
 
@@ -10829,8 +10838,8 @@ schema:passengerSequenceNumber rdfs:comment "The passenger's sequence number as 
                                schema:rangeIncludes schema:Text .
 
 
-schema:paymentAccepted rdfs:label "paymentAccepted"@en ;
-                       schema:domainIncludes schema:LocalBusiness ;
+schema:paymentAccepted schema:domainIncludes schema:LocalBusiness ;
+                       rdfs:label "paymentAccepted"@en ;
                        schema:rangeIncludes schema:Text ;
                        rdfs:comment "Cash, Credit Card, Cryptocurrency, Local Exchange Tradings System, etc."@en .
 
@@ -10894,8 +10903,8 @@ schema:percentile25 schema:rangeIncludes schema:Number ;
                     schema:domainIncludes schema:QuantitativeValueDistribution .
 
 
-schema:percentile75 schema:rangeIncludes schema:Number ;
-                    rdfs:comment "The 75th percentile value."@en ;
+schema:percentile75 rdfs:comment "The 75th percentile value."@en ;
+                    schema:rangeIncludes schema:Number ;
                     rdfs:label "percentile75"@en ;
                     schema:category "issue-1698"@en ;
                     dc:source <https://github.com/schemaorg/schemaorg/issues/1698> ;
@@ -10923,8 +10932,8 @@ schema:performerIn schema:domainIncludes schema:Person ;
                    rdfs:label "performerIn"@en .
 
 
-schema:performers schema:supersededBy schema:performer ;
-                  rdfs:label "performers"@en ;
+schema:performers rdfs:label "performers"@en ;
+                  schema:supersededBy schema:performer ;
                   schema:domainIncludes schema:Event ;
                   rdfs:comment "The main performer or performers of the event&#x2014;for example, a presenter, musician, or actor."@en ;
                   schema:rangeIncludes schema:Organization ,
@@ -10932,8 +10941,8 @@ schema:performers schema:supersededBy schema:performer ;
 
 
 schema:permissionType schema:domainIncludes schema:DigitalDocumentPermission ;
-                      rdfs:comment "The type of permission granted the person, organization, or audience."@en ;
                       rdfs:label "permissionType"@en ;
+                      rdfs:comment "The type of permission granted the person, organization, or audience."@en ;
                       schema:rangeIncludes schema:DigitalDocumentPermissionType .
 
 
@@ -11020,13 +11029,13 @@ schema:postOfficeBoxNumber rdfs:label "postOfficeBoxNumber"@en ;
 
 schema:potentialAction rdfs:label "potentialAction"@en ;
                        schema:domainIncludes schema:Thing ;
-                       rdfs:comment "Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role."@en ;
-                       schema:rangeIncludes schema:Action .
+                       schema:rangeIncludes schema:Action ;
+                       rdfs:comment "Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role."@en .
 
 
 schema:predecessorOf schema:rangeIncludes schema:ProductModel ;
-                     rdfs:comment "A pointer from a previous, often discontinued variant of the product to its newer variant."@en ;
                      schema:domainIncludes schema:ProductModel ;
+                     rdfs:comment "A pointer from a previous, often discontinued variant of the product to its newer variant."@en ;
                      rdfs:label "predecessorOf"@en .
 
 
@@ -11049,14 +11058,14 @@ schema:previousStartDate schema:rangeIncludes schema:Date ;
                          rdfs:comment "Used in conjunction with eventStatus for rescheduled or cancelled events. This property contains the previously scheduled start date. For rescheduled events, the startDate property should be used for the newly scheduled start date. In the (rare) case of an event that has been postponed and rescheduled multiple times, this field may be repeated."@en .
 
 
-schema:price schema:domainIncludes schema:PriceSpecification ,
+schema:price rdfs:comment """The offer price of a product, or of a price component when attached to PriceSpecification and its subtypes.\\n\\nUsage guidelines:\\n\\n* Use the [[priceCurrency]] property (with standard formats: [ISO 4217 currency format](http://en.wikipedia.org/wiki/ISO_4217) e.g. \"USD\"; [Ticker symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies) for cryptocurrencies e.g. \"BTC\"; well known names for [Local Exchange Tradings Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system) (LETS) and other currency types e.g. \"Ithaca HOUR\") instead of including [ambiguous symbols](http://en.wikipedia.org/wiki/Dollar_sign#Currencies_that_use_the_dollar_or_peso_sign) such as '$' in the value.\\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator.\\n* Note that both [RDFa](http://www.w3.org/TR/xhtml-rdfa-primer/#using-the-content-attribute) and Microdata syntax allow the use of a \"content=\" attribute for publishing simple machine-readable values alongside more human-friendly formatting.\\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similiar Unicode symbols.
+      """@en ;
+             schema:domainIncludes schema:PriceSpecification ,
                                    schema:TradeAction ,
                                    schema:Offer ;
              rdfs:label "price"@en ;
              schema:rangeIncludes schema:Number ,
-                                  schema:Text ;
-             rdfs:comment """The offer price of a product, or of a price component when attached to PriceSpecification and its subtypes.\\n\\nUsage guidelines:\\n\\n* Use the [[priceCurrency]] property (with standard formats: [ISO 4217 currency format](http://en.wikipedia.org/wiki/ISO_4217) e.g. \"USD\"; [Ticker symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies) for cryptocurrencies e.g. \"BTC\"; well known names for [Local Exchange Tradings Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system) (LETS) and other currency types e.g. \"Ithaca HOUR\") instead of including [ambiguous symbols](http://en.wikipedia.org/wiki/Dollar_sign#Currencies_that_use_the_dollar_or_peso_sign) such as '$' in the value.\\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator.\\n* Note that both [RDFa](http://www.w3.org/TR/xhtml-rdfa-primer/#using-the-content-attribute) and Microdata syntax allow the use of a \"content=\" attribute for publishing simple machine-readable values alongside more human-friendly formatting.\\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similiar Unicode symbols.
-      """@en .
+                                  schema:Text .
 
 
 schema:priceComponent dc:source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_GoodRelationsTerms> ;
@@ -11066,10 +11075,10 @@ schema:priceComponent dc:source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgS
                       schema:rangeIncludes schema:UnitPriceSpecification .
 
 
-schema:priceCurrency schema:domainIncludes schema:Reservation ,
-                                           schema:TradeAction ,
-                                           schema:Ticket ,
-                                           schema:PriceSpecification ;
+schema:priceCurrency schema:domainIncludes schema:TradeAction ,
+                                           schema:Reservation ,
+                                           schema:PriceSpecification ,
+                                           schema:Ticket ;
                      rdfs:label "priceCurrency"@en ;
                      schema:domainIncludes schema:Offer ;
                      schema:rangeIncludes schema:Text ;
@@ -11082,8 +11091,8 @@ schema:priceRange rdfs:label "priceRange"@en ;
                   rdfs:comment "The price range of the business, for example ```$$$```."@en .
 
 
-schema:priceSpecification schema:rangeIncludes schema:PriceSpecification ;
-                          rdfs:comment "One or more detailed price specifications, indicating the unit price and delivery or payment charges."@en ;
+schema:priceSpecification rdfs:comment "One or more detailed price specifications, indicating the unit price and delivery or payment charges."@en ;
+                          schema:rangeIncludes schema:PriceSpecification ;
                           rdfs:label "priceSpecification"@en ;
                           schema:domainIncludes schema:Demand ,
                                                 schema:TradeAction ,
@@ -11103,15 +11112,15 @@ schema:priceValidUntil schema:domainIncludes schema:Offer ;
 
 
 schema:primaryImageOfPage rdfs:comment "Indicates the main image on the page."@en ;
-                          schema:rangeIncludes schema:ImageObject ;
                           rdfs:label "primaryImageOfPage"@en ;
+                          schema:rangeIncludes schema:ImageObject ;
                           schema:domainIncludes schema:WebPage .
 
 
 schema:printColumn rdfs:comment "The number of the column in which the NewsArticle appears in the print edition."@en ;
                    schema:domainIncludes schema:NewsArticle ;
-                   rdfs:label "printColumn"@en ;
-                   schema:rangeIncludes schema:Text .
+                   schema:rangeIncludes schema:Text ;
+                   rdfs:label "printColumn"@en .
 
 
 schema:printEdition schema:rangeIncludes schema:Text ;
@@ -11145,28 +11154,28 @@ schema:processorRequirements schema:domainIncludes schema:SoftwareApplication ;
 
 
 schema:producer schema:domainIncludes schema:CreativeWork ;
-                schema:rangeIncludes schema:Person ;
                 rdfs:comment "The person or organization who produced the work (e.g. music album, movie, tv/radio series etc.)."@en ;
+                schema:rangeIncludes schema:Person ;
                 rdfs:label "producer"@en ;
                 schema:rangeIncludes schema:Organization .
 
 
-schema:produces rdfs:comment "The tangible thing generated by the service, e.g. a passport, permit, etc."@en ;
-                schema:supersededBy schema:serviceOutput ;
+schema:produces schema:supersededBy schema:serviceOutput ;
+                rdfs:comment "The tangible thing generated by the service, e.g. a passport, permit, etc."@en ;
                 rdfs:label "produces"@en ;
                 schema:rangeIncludes schema:Thing ;
                 schema:domainIncludes schema:Service .
 
 
-schema:productSupported schema:domainIncludes schema:ContactPoint ;
+schema:productSupported schema:rangeIncludes schema:Product ;
+                        schema:domainIncludes schema:ContactPoint ;
                         rdfs:label "productSupported"@en ;
-                        schema:rangeIncludes schema:Product ;
                         rdfs:comment "The product or service this support contact point is related to (such as product support for a particular product line). This can be a specific product or product line (e.g. \"iPhone\") or a general category of products or services (e.g. \"smartphones\")."@en ;
                         schema:rangeIncludes schema:Text .
 
 
-schema:productionCompany schema:domainIncludes schema:MovieSeries ,
-                                               schema:Movie ,
+schema:productionCompany schema:domainIncludes schema:Movie ,
+                                               schema:MovieSeries ,
                                                schema:TVSeries ,
                                                schema:MediaObject ,
                                                schema:CreativeWorkSeason ,
@@ -11178,8 +11187,8 @@ schema:productionCompany schema:domainIncludes schema:MovieSeries ,
                          rdfs:comment "The production company or studio responsible for the item e.g. series, video game, episode etc."@en .
 
 
-schema:productionDate rdfs:comment "The date of production of the item, e.g. vehicle."@en ;
-                      dc:source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group> ;
+schema:productionDate dc:source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group> ;
+                      rdfs:comment "The date of production of the item, e.g. vehicle."@en ;
                       schema:domainIncludes schema:Product ,
                                             schema:Vehicle ;
                       rdfs:label "productionDate"@en ;
@@ -11223,20 +11232,20 @@ schema:propertyID schema:rangeIncludes schema:URL ;
 a URL indicating the type of the property, either pointing to an external vocabulary, or a Web resource that describes the property (e.g. a glossary entry).
 Standards bodies should promote a standard prefix for the identifiers of properties from their standards."""@en ;
                   schema:rangeIncludes schema:Text ;
-                  schema:domainIncludes schema:PropertyValue ;
-                  rdfs:label "propertyID"@en .
+                  rdfs:label "propertyID"@en ;
+                  schema:domainIncludes schema:PropertyValue .
 
 
 schema:proteinContent schema:domainIncludes schema:NutritionInformation ;
-                      schema:rangeIncludes schema:Mass ;
+                      rdfs:label "proteinContent"@en ;
                       rdfs:comment "The number of grams of protein."@en ;
-                      rdfs:label "proteinContent"@en .
+                      schema:rangeIncludes schema:Mass .
 
 
 schema:provider rdfs:comment "The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller."@en ;
-                schema:domainIncludes schema:Invoice ,
-                                      schema:ParcelDelivery ,
-                                      schema:Trip ;
+                schema:domainIncludes schema:Trip ,
+                                      schema:Invoice ,
+                                      schema:ParcelDelivery ;
                 rdfs:label "provider"@en ;
                 schema:domainIncludes schema:Reservation ;
                 schema:rangeIncludes schema:Person ;
@@ -11289,21 +11298,21 @@ schema:publisher rdfs:label "publisher"@en ;
                  schema:rangeIncludes schema:Person .
 
 
-schema:publishingPrinciples rdfs:comment """The publishingPrinciples property indicates (typically via [[URL]]) a document describing the editorial principles of an [[Organization]] (or individual e.g. a [[Person]] writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a [[CreativeWork]] (e.g. [[NewsArticle]]) the principles are those of the party primarily responsible for the creation of the [[CreativeWork]].
+schema:publishingPrinciples schema:domainIncludes schema:Organization ;
+                            schema:rangeIncludes schema:URL ,
+                                                 schema:CreativeWork ;
+                            rdfs:label "publishingPrinciples"@en ;
+                            schema:domainIncludes schema:CreativeWork ;
+                            rdfs:comment """The publishingPrinciples property indicates (typically via [[URL]]) a document describing the editorial principles of an [[Organization]] (or individual e.g. a [[Person]] writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a [[CreativeWork]] (e.g. [[NewsArticle]]) the principles are those of the party primarily responsible for the creation of the [[CreativeWork]].
 
 While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a [[funder]]) can be expressed using schema.org terminology.
 """@en ;
-                            schema:domainIncludes schema:Organization ;
-                            schema:rangeIncludes schema:URL ,
-                                                 schema:CreativeWork ;
-                            schema:domainIncludes schema:CreativeWork ;
-                            rdfs:label "publishingPrinciples"@en ;
                             schema:domainIncludes schema:Person .
 
 
-schema:purchaseDate schema:domainIncludes schema:Product ;
+schema:purchaseDate schema:domainIncludes schema:Product ,
+                                          schema:Vehicle ;
                     rdfs:label "purchaseDate"@en ;
-                    schema:domainIncludes schema:Vehicle ;
                     rdfs:comment "The date the item e.g. vehicle was purchased by the current owner."@en ;
                     schema:rangeIncludes schema:Date ;
                     dc:source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group> .
@@ -11385,8 +11394,8 @@ schema:recordedIn rdfs:comment "The CreativeWork that captured all or part of th
                   schema:inverseOf schema:recordedAt .
 
 
-schema:recordingOf schema:rangeIncludes schema:MusicComposition ;
-                   rdfs:comment "The composition this track is a recording of."@en ;
+schema:recordingOf rdfs:comment "The composition this track is a recording of."@en ;
+                   schema:rangeIncludes schema:MusicComposition ;
                    schema:domainIncludes schema:MusicRecording ;
                    schema:inverseOf schema:recordedAs ;
                    rdfs:label "recordingOf"@en ;
@@ -11401,15 +11410,15 @@ schema:referenceQuantity schema:domainIncludes schema:UnitPriceSpecification ;
                          rdfs:comment "The reference quantity for which a certain price applies, e.g. 1 EUR per 4 kWh of electricity. This property is a replacement for unitOfMeasurement for the advanced cases where the price does not relate to a standard unit."@en .
 
 
-schema:referencesOrder rdfs:label "referencesOrder"@en ;
-                       rdfs:comment "The Order(s) related to this Invoice. One or more Orders may be combined into a single Invoice."@en ;
+schema:referencesOrder rdfs:comment "The Order(s) related to this Invoice. One or more Orders may be combined into a single Invoice."@en ;
+                       rdfs:label "referencesOrder"@en ;
                        schema:domainIncludes schema:Invoice ;
                        schema:rangeIncludes schema:Order .
 
 
-schema:regionsAllowed rdfs:comment "The regions where the media is allowed. If not specified, then it's assumed to be allowed everywhere. Specify the countries in [ISO 3166 format](http://en.wikipedia.org/wiki/ISO_3166)."@en ;
-                      schema:domainIncludes schema:MediaObject ;
+schema:regionsAllowed schema:domainIncludes schema:MediaObject ;
                       schema:rangeIncludes schema:Place ;
+                      rdfs:comment "The regions where the media is allowed. If not specified, then it's assumed to be allowed everywhere. Specify the countries in [ISO 3166 format](http://en.wikipedia.org/wiki/ISO_3166)."@en ;
                       rdfs:label "regionsAllowed"@en .
 
 
@@ -11439,9 +11448,9 @@ schema:releaseNotes schema:rangeIncludes schema:URL ;
 
 
 schema:releaseOf schema:domainIncludes schema:MusicRelease ;
-                 rdfs:comment "The album this is a release of."@en ;
-                 dc:source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#MBZ> ;
                  schema:rangeIncludes schema:MusicAlbum ;
+                 dc:source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#MBZ> ;
+                 rdfs:comment "The album this is a release of."@en ;
                  schema:inverseOf schema:albumRelease ;
                  rdfs:label "releaseOf"@en .
 
@@ -11452,8 +11461,8 @@ schema:releasedEvent schema:domainIncludes schema:CreativeWork ;
                      schema:rangeIncludes schema:PublicationEvent .
 
 
-schema:relevantOccupation schema:rangeIncludes schema:Occupation ;
-                          schema:domainIncludes schema:JobPosting ;
+schema:relevantOccupation schema:domainIncludes schema:JobPosting ;
+                          schema:rangeIncludes schema:Occupation ;
                           rdfs:label "relevantOccupation"@en ;
                           dc:source <https://github.com/schemaorg/schemaorg/issues/1698> ;
                           rdfs:comment "The Occupation for the JobPosting."@en ;
@@ -11504,8 +11513,8 @@ schema:requiredMaxAge schema:domainIncludes schema:PeopleAudience ;
                       rdfs:comment "Audiences defined by a person's maximum age."@en .
 
 
-schema:requiredMinAge schema:rangeIncludes schema:Integer ;
-                      rdfs:comment "Audiences defined by a person's minimum age."@en ;
+schema:requiredMinAge rdfs:comment "Audiences defined by a person's minimum age."@en ;
+                      schema:rangeIncludes schema:Integer ;
                       rdfs:label "requiredMinAge"@en ;
                       schema:domainIncludes schema:PeopleAudience .
 
@@ -11522,8 +11531,8 @@ schema:requirements rdfs:comment "Component dependency requirements for applicat
                     schema:rangeIncludes schema:Text ,
                                          schema:URL ;
                     schema:domainIncludes schema:SoftwareApplication ;
-                    schema:supersededBy schema:softwareRequirements ;
-                    rdfs:label "requirements"@en .
+                    rdfs:label "requirements"@en ;
+                    schema:supersededBy schema:softwareRequirements .
 
 
 schema:requiresSubscription rdfs:label "requiresSubscription"@en ;
@@ -11548,10 +11557,10 @@ schema:reservationId schema:domainIncludes schema:Reservation ;
                      rdfs:label "reservationId"@en .
 
 
-schema:reservationStatus rdfs:label "reservationStatus"@en ;
-                         schema:rangeIncludes schema:ReservationStatusType ;
-                         rdfs:comment "The current status of the reservation."@en ;
-                         schema:domainIncludes schema:Reservation .
+schema:reservationStatus schema:rangeIncludes schema:ReservationStatusType ;
+                         rdfs:label "reservationStatus"@en ;
+                         schema:domainIncludes schema:Reservation ;
+                         rdfs:comment "The current status of the reservation."@en .
 
 
 schema:reservedTicket schema:rangeIncludes schema:Ticket ;
@@ -11577,9 +11586,9 @@ schema:review schema:rangeIncludes schema:Review ;
                                     schema:Place ,
                                     schema:CreativeWork ;
               rdfs:label "review"@en ;
-              schema:domainIncludes schema:Event ,
-                                    schema:Offer ;
-              rdfs:comment "A review of the item."@en .
+              schema:domainIncludes schema:Event ;
+              rdfs:comment "A review of the item."@en ;
+              schema:domainIncludes schema:Offer .
 
 
 schema:reviewAspect schema:domainIncludes schema:Rating ;
@@ -11629,8 +11638,8 @@ schema:reviews schema:supersededBy schema:review ;
 
 schema:roleName schema:rangeIncludes schema:URL ,
                                      schema:Text ;
-                schema:domainIncludes schema:Role ;
                 rdfs:label "roleName"@en ;
+                schema:domainIncludes schema:Role ;
                 rdfs:comment "A role played, performed or filled by a person or organization. For example, the team of creators for a comic book might fill the roles named 'inker', 'penciller', and 'letterer'; or an athlete in a SportsTeam might play in the position named 'Quarterback'."@en .
 
 
@@ -11648,8 +11657,8 @@ schema:runtime schema:supersededBy schema:runtimePlatform ;
 
 
 schema:runtimePlatform schema:rangeIncludes schema:Text ;
-                       schema:domainIncludes schema:SoftwareSourceCode ;
                        rdfs:comment "Runtime platform or script interpreter dependencies (Example - Java v1, Python2.3, .Net Framework 3.0)."@en ;
+                       schema:domainIncludes schema:SoftwareSourceCode ;
                        rdfs:label "runtimePlatform"@en .
 
 
@@ -11705,8 +11714,8 @@ schema:screenshot rdfs:label "screenshot"@en ;
                   schema:domainIncludes schema:SoftwareApplication .
 
 
-schema:seasons schema:supersededBy schema:season ;
-               schema:rangeIncludes schema:CreativeWorkSeason ;
+schema:seasons schema:rangeIncludes schema:CreativeWorkSeason ;
+               schema:supersededBy schema:season ;
                schema:domainIncludes schema:VideoGameSeries ,
                                      schema:TVSeries ;
                rdfs:label "seasons"@en ;
@@ -11722,8 +11731,8 @@ schema:seatNumber schema:domainIncludes schema:Seat ;
 
 schema:seatRow rdfs:label "seatRow"@en ;
                schema:rangeIncludes schema:Text ;
-               rdfs:comment "The row location of the reserved seat (e.g., B)."@en ;
-               schema:domainIncludes schema:Seat .
+               schema:domainIncludes schema:Seat ;
+               rdfs:comment "The row location of the reserved seat (e.g., B)."@en .
 
 
 schema:seatSection rdfs:comment "The section location of the reserved seat (e.g. Orchestra)."@en ;
@@ -11746,9 +11755,9 @@ schema:securityScreening rdfs:label "securityScreening"@en ;
 
 
 schema:seeks rdfs:comment "A pointer to products or services sought by the organization or person (demand)."@en ;
-             schema:domainIncludes schema:Organization ,
-                                   schema:Person ;
+             schema:domainIncludes schema:Organization ;
              schema:rangeIncludes schema:Demand ;
+             schema:domainIncludes schema:Person ;
              rdfs:label "seeks"@en .
 
 
@@ -11825,8 +11834,8 @@ schema:serviceUrl schema:domainIncludes schema:ServiceChannel ;
 
 
 schema:servingSize schema:domainIncludes schema:NutritionInformation ;
-                   schema:rangeIncludes schema:Text ;
                    rdfs:label "servingSize"@en ;
+                   schema:rangeIncludes schema:Text ;
                    rdfs:comment "The serving size, in terms of the number of volume or mass."@en .
 
 
@@ -11856,8 +11865,8 @@ schema:significantLink rdfs:label "significantLink"@en ;
 
 
 schema:significantLinks schema:domainIncludes schema:WebPage ;
-                        rdfs:label "significantLinks"@en ;
                         schema:supersededBy schema:significantLink ;
+                        rdfs:label "significantLinks"@en ;
                         schema:rangeIncludes schema:URL ;
                         rdfs:comment "The most significant URLs on the page. Typically, these are the non-navigation links that are clicked on the most."@en .
 
@@ -11876,8 +11885,8 @@ schema:slogan rdfs:comment "A slogan or motto associated with the item."@en ;
               schema:domainIncludes schema:Product ;
               rdfs:label "slogan"@en ;
               schema:domainIncludes schema:Place ,
-                                    schema:Organization ,
                                     schema:Brand ,
+                                    schema:Organization ,
                                     schema:Service .
 
 
@@ -11914,8 +11923,8 @@ schema:softwareRequirements rdfs:comment "Component dependency requirements for 
 
 
 schema:softwareVersion schema:rangeIncludes schema:Text ;
-                       rdfs:label "softwareVersion"@en ;
                        rdfs:comment "Version of the software instance."@en ;
+                       rdfs:label "softwareVersion"@en ;
                        schema:domainIncludes schema:SoftwareApplication .
 
 
@@ -11934,6 +11943,9 @@ schema:spatial schema:rangeIncludes schema:Place ;
 
 schema:speakable dc:source <https://github.com/schemaorg/schemaorg/issues/1389> ;
                  schema:category "issue-1389"@en ;
+                 schema:domainIncludes schema:Article ;
+                 schema:rangeIncludes schema:SpeakableSpecification ;
+                 schema:domainIncludes schema:WebPage ;
                  rdfs:comment """Indicates sections of a Web page that are particularly 'speakable' in the sense of being highlighted as being especially appropriate for text-to-speech conversion. Other sections of a page may also be usefully spoken in particular circumstances; the 'speakable' property serves to indicate the parts most likely to be generally useful for speech.
 
 The *speakable* property can be repeated an arbitrary number of times, with three kinds of possible 'content-locator' values:
@@ -11948,9 +11960,6 @@ The *speakable* property can be repeated an arbitrary number of times, with thre
 For more sophisticated markup of speakable sections beyond simple ID references, either CSS selectors or XPath expressions to pick out document section(s) as speakable. For this
 we define a supporting type, [[SpeakableSpecification]]  which is defined to be a possible value of the *speakable* property.
          """@en ;
-                 schema:domainIncludes schema:Article ;
-                 schema:rangeIncludes schema:SpeakableSpecification ;
-                 schema:domainIncludes schema:WebPage ;
                  schema:rangeIncludes schema:URL ;
                  rdfs:label "speakable"@en .
 
@@ -11961,17 +11970,17 @@ schema:specialCommitments rdfs:comment "Any special commitments associated with 
                           schema:domainIncludes schema:JobPosting .
 
 
-schema:specialOpeningHoursSpecification rdfs:comment """The special opening hours of a certain place.\\n\\nUse this to explicitly override general opening hours brought in scope by [[openingHoursSpecification]] or [[openingHours]].
-      """@en ;
-                                        schema:domainIncludes schema:Place ;
+schema:specialOpeningHoursSpecification schema:domainIncludes schema:Place ;
                                         rdfs:label "specialOpeningHoursSpecification"@en ;
+                                        rdfs:comment """The special opening hours of a certain place.\\n\\nUse this to explicitly override general opening hours brought in scope by [[openingHoursSpecification]] or [[openingHours]].
+      """@en ;
                                         schema:rangeIncludes schema:OpeningHoursSpecification .
 
 
 schema:specialty rdfs:label "specialty"@en ;
                  schema:domainIncludes schema:WebPage ;
-                 rdfs:comment "One of the domain specialities to which this web page's content applies."@en ;
-                 schema:rangeIncludes schema:Specialty .
+                 schema:rangeIncludes schema:Specialty ;
+                 rdfs:comment "One of the domain specialities to which this web page's content applies."@en .
 
 
 schema:sport schema:domainIncludes schema:SportsOrganization ;
@@ -11983,8 +11992,8 @@ schema:sport schema:domainIncludes schema:SportsOrganization ;
 
 schema:spouse schema:rangeIncludes schema:Person ;
               schema:domainIncludes schema:Person ;
-              rdfs:label "spouse"@en ;
-              rdfs:comment "The person's spouse."@en .
+              rdfs:comment "The person's spouse."@en ;
+              rdfs:label "spouse"@en .
 
 
 schema:starRating rdfs:comment "An official rating for a lodging business or food establishment, e.g. from national associations or standards bodies. Use the author property to indicate the rating organization, e.g. as an Organization with name such as (e.g. HOTREC, DEHOGA, WHR, or Hotelstars)."@en ;
@@ -12007,8 +12016,8 @@ schema:startTime schema:rangeIncludes schema:Time ;
 schema:steeringPosition rdfs:comment "The position of the steering wheel or similar device (mostly for cars)."@en ;
                         schema:domainIncludes schema:Vehicle ;
                         dc:source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group> ;
-                        schema:rangeIncludes schema:SteeringPositionValue ;
-                        rdfs:label "steeringPosition"@en .
+                        rdfs:label "steeringPosition"@en ;
+                        schema:rangeIncludes schema:SteeringPositionValue .
 
 
 schema:stepValue rdfs:label "stepValue"@en ;
@@ -12021,8 +12030,8 @@ schema:steps schema:rangeIncludes schema:Text ;
              schema:domainIncludes schema:HowToSection ;
              schema:rangeIncludes schema:ItemList ;
              rdfs:label "steps"@en ;
-             schema:domainIncludes schema:HowTo ;
              rdfs:comment "A single step item (as HowToStep, text, document, video, etc.) or a HowToSection (originally misnamed 'steps'; 'step' is preferred)."@en ;
+             schema:domainIncludes schema:HowTo ;
              schema:supersededBy schema:step ;
              schema:rangeIncludes schema:CreativeWork .
 
@@ -12071,18 +12080,18 @@ schema:subjectOf schema:rangeIncludes schema:Event ;
                  rdfs:comment "A CreativeWork or Event about this Thing."@en .
 
 
-schema:subtitleLanguage schema:domainIncludes schema:Movie ,
-                                              schema:TVEpisode ;
+schema:subtitleLanguage schema:domainIncludes schema:Movie ;
                         rdfs:comment "Languages in which subtitles/captions are available, in [IETF BCP 47 standard format](http://tools.ietf.org/html/bcp47)."@en ;
-                        schema:domainIncludes schema:ScreeningEvent ;
+                        schema:domainIncludes schema:TVEpisode ,
+                                              schema:ScreeningEvent ;
                         schema:rangeIncludes schema:Language ;
                         rdfs:label "subtitleLanguage"@en ;
                         schema:rangeIncludes schema:Text .
 
 
 schema:successorOf schema:rangeIncludes schema:ProductModel ;
-                   rdfs:label "successorOf"@en ;
                    rdfs:comment "A pointer from a newer variant of a product  to its previous, often discontinued predecessor."@en ;
+                   rdfs:label "successorOf"@en ;
                    schema:domainIncludes schema:ProductModel .
 
 
@@ -12166,21 +12175,21 @@ schema:targetUrl rdfs:comment "The URL of a node in an established educational f
                  rdfs:label "targetUrl"@en .
 
 
-schema:temporal rdfs:comment """The \"temporal\" property can be used in cases where more specific properties
+schema:temporal rdfs:label "temporal"@en ;
+                rdfs:comment """The \"temporal\" property can be used in cases where more specific properties
 (e.g. [[temporalCoverage]], [[dateCreated]], [[dateModified]], [[datePublished]]) are not known to be appropriate."""@en ;
-                rdfs:label "temporal"@en ;
                 schema:domainIncludes schema:CreativeWork ;
                 schema:rangeIncludes schema:Text ,
                                      schema:DateTime .
 
 
-schema:temporalCoverage schema:rangeIncludes schema:Text ;
-                        rdfs:comment """The temporalCoverage of a CreativeWork indicates the period that the content applies to, i.e. that it describes, either as a DateTime or as a textual string indicating a time period in [ISO 8601 time interval format](https://en.wikipedia.org/wiki/ISO_8601#Time_intervals). In
+schema:temporalCoverage rdfs:comment """The temporalCoverage of a CreativeWork indicates the period that the content applies to, i.e. that it describes, either as a DateTime or as a textual string indicating a time period in [ISO 8601 time interval format](https://en.wikipedia.org/wiki/ISO_8601#Time_intervals). In
       the case of a Dataset it will typically indicate the relevant time period in a precise notation (e.g. for a 2011 census dataset, the year 2011 would be written \"2011/2012\"). Other forms of content e.g. ScholarlyArticle, Book, TVSeries or TVEpisode may indicate their temporalCoverage in broader terms - textually or via well-known URL.
       Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via \"1939/1945\".
 
 Open-ended date ranges can be written with \"..\" in place of the end date. For example, \"2015-11/..\" indicates a range beginning in November 2015 and with no specified final date. This is tentative and might be updated in future when ISO 8601 is officially updated."""@en ;
-                        schema:rangeIncludes schema:DateTime ,
+                        schema:rangeIncludes schema:Text ,
+                                             schema:DateTime ,
                                              schema:URL ;
                         schema:domainIncludes schema:CreativeWork ;
                         rdfs:label "temporalCoverage"@en .
@@ -12296,8 +12305,8 @@ schema:trackingUrl schema:domainIncludes schema:ParcelDelivery ;
 
 
 schema:tracks rdfs:label "tracks"@en ;
-              rdfs:comment "A music recording (track)&#x2014;usually a single song."@en ;
               schema:domainIncludes schema:MusicPlaylist ;
+              rdfs:comment "A music recording (track)&#x2014;usually a single song."@en ;
               schema:rangeIncludes schema:MusicRecording ;
               schema:supersededBy schema:track ;
               schema:domainIncludes schema:MusicGroup .
@@ -12349,9 +12358,9 @@ schema:translator rdfs:comment "Organization or person who adapts a creative wor
                   rdfs:label "translator"@en .
 
 
-schema:typeOfBed rdfs:label "typeOfBed"@en ;
-                 schema:rangeIncludes schema:BedType ,
-                                      schema:Text ;
+schema:typeOfBed schema:rangeIncludes schema:BedType ;
+                 rdfs:label "typeOfBed"@en ;
+                 schema:rangeIncludes schema:Text ;
                  rdfs:comment "The type of bed to which the BedDetail refers, i.e. the type of bed available in the quantity indicated by quantity."@en ;
                  dc:source <https://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#STI_Accommodation_Ontology> ;
                  schema:domainIncludes schema:BedDetails .
@@ -12376,14 +12385,14 @@ schema:underName rdfs:comment "The person or organization the reservation or tic
                  schema:domainIncludes schema:Ticket ;
                  schema:rangeIncludes schema:Organization ;
                  schema:domainIncludes schema:Reservation ;
-                 schema:rangeIncludes schema:Person ;
-                 rdfs:label "underName"@en .
+                 rdfs:label "underName"@en ;
+                 schema:rangeIncludes schema:Person .
 
 
-schema:unitText schema:domainIncludes schema:QuantitativeValue ;
-                rdfs:label "unitText"@en ;
-                rdfs:comment """A string or text indicating the unit of measurement. Useful if you cannot provide a standard unit code for
+schema:unitText rdfs:comment """A string or text indicating the unit of measurement. Useful if you cannot provide a standard unit code for
 <a href='unitCode'>unitCode</a>."""@en ;
+                schema:domainIncludes schema:QuantitativeValue ;
+                rdfs:label "unitText"@en ;
                 schema:domainIncludes schema:UnitPriceSpecification ,
                                       schema:PropertyValue ,
                                       schema:TypeAndQuantityNode ;
@@ -12429,13 +12438,13 @@ schema:validFor rdfs:comment "The duration of validity of a permit or similar th
 
 schema:validFrom schema:domainIncludes schema:LocationFeatureSpecification ,
                                        schema:Permit ;
-                 rdfs:label "validFrom"@en ;
                  schema:rangeIncludes schema:Date ;
+                 rdfs:label "validFrom"@en ;
                  schema:domainIncludes schema:Offer ;
                  rdfs:comment "The date when the item becomes valid."@en ;
                  schema:domainIncludes schema:OpeningHoursSpecification ,
-                                       schema:MonetaryAmount ,
-                                       schema:Demand ;
+                                       schema:Demand ,
+                                       schema:MonetaryAmount ;
                  schema:rangeIncludes schema:DateTime ;
                  schema:domainIncludes schema:PriceSpecification .
 
@@ -12452,9 +12461,9 @@ schema:validThrough schema:domainIncludes schema:PriceSpecification ;
                                           schema:JobPosting ,
                                           schema:Demand ;
                     schema:rangeIncludes schema:Date ;
-                    schema:domainIncludes schema:OpeningHoursSpecification ,
-                                          schema:MonetaryAmount ;
+                    schema:domainIncludes schema:OpeningHoursSpecification ;
                     rdfs:label "validThrough"@en ;
+                    schema:domainIncludes schema:MonetaryAmount ;
                     rdfs:comment "The date after when the item is not valid. For example the end of an offer, salary period, or a period of opening hours."@en ;
                     schema:domainIncludes schema:LocationFeatureSpecification .
 
@@ -12488,8 +12497,8 @@ schema:valueMaxLength schema:rangeIncludes schema:Number ;
                       rdfs:comment "Specifies the allowed range for number of characters in a literal value."@en .
 
 
-schema:valueMinLength rdfs:label "valueMinLength"@en ;
-                      schema:domainIncludes schema:PropertyValueSpecification ;
+schema:valueMinLength schema:domainIncludes schema:PropertyValueSpecification ;
+                      rdfs:label "valueMinLength"@en ;
                       rdfs:comment "Specifies the minimum allowed range for number of characters in a literal value."@en ;
                       schema:rangeIncludes schema:Number .
 
@@ -12502,13 +12511,13 @@ schema:valueName rdfs:label "valueName"@en ;
 
 schema:valuePattern schema:rangeIncludes schema:Text ;
                     rdfs:comment "Specifies a regular expression for testing literal values according to the HTML spec."@en ;
-                    rdfs:label "valuePattern"@en ;
-                    schema:domainIncludes schema:PropertyValueSpecification .
+                    schema:domainIncludes schema:PropertyValueSpecification ;
+                    rdfs:label "valuePattern"@en .
 
 
-schema:valueReference schema:rangeIncludes schema:QuantitativeValue ;
+schema:valueReference schema:rangeIncludes schema:Enumeration ,
+                                           schema:QuantitativeValue ;
                       schema:domainIncludes schema:QualitativeValue ;
-                      schema:rangeIncludes schema:Enumeration ;
                       rdfs:label "valueReference"@en ;
                       schema:rangeIncludes schema:StructuredValue ;
                       schema:domainIncludes schema:QuantitativeValue ;
@@ -12524,15 +12533,15 @@ schema:valueRequired schema:rangeIncludes schema:Boolean ;
                      rdfs:comment "Whether the property must be filled in to complete the action.  Default is false."@en .
 
 
-schema:vatID rdfs:label "vatID"@en ;
-             schema:domainIncludes schema:Organization ,
-                                   schema:Person ;
+schema:vatID schema:domainIncludes schema:Organization ;
+             rdfs:label "vatID"@en ;
+             schema:domainIncludes schema:Person ;
              schema:rangeIncludes schema:Text ;
              rdfs:comment "The Value-added Tax ID of the organization or person."@en .
 
 
-schema:vehicleConfiguration schema:rangeIncludes schema:Text ;
-                            rdfs:label "vehicleConfiguration"@en ;
+schema:vehicleConfiguration rdfs:label "vehicleConfiguration"@en ;
+                            schema:rangeIncludes schema:Text ;
                             rdfs:comment "A short text indicating the configuration of the vehicle, e.g. '5dr hatchback ST 2.5 MT 225 hp' or 'limited edition'."@en ;
                             schema:domainIncludes schema:Vehicle ;
                             dc:source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group> .
@@ -12566,11 +12575,11 @@ schema:vehicleModelDate schema:domainIncludes schema:Vehicle ;
                         schema:rangeIncludes schema:Date .
 
 
-schema:vehicleSeatingCapacity rdfs:label "vehicleSeatingCapacity"@en ;
+schema:vehicleSeatingCapacity rdfs:comment "The number of passengers that can be seated in the vehicle, both in terms of the physical space available, and in terms of limitations set by law.\\n\\nTypical unit code(s): C62 for persons."@en ;
                               dc:source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group> ;
-                              rdfs:comment "The number of passengers that can be seated in the vehicle, both in terms of the physical space available, and in terms of limitations set by law.\\n\\nTypical unit code(s): C62 for persons."@en ;
-                              schema:rangeIncludes schema:QuantitativeValue ,
-                                                   schema:Number ;
+                              schema:rangeIncludes schema:QuantitativeValue ;
+                              rdfs:label "vehicleSeatingCapacity"@en ;
+                              schema:rangeIncludes schema:Number ;
                               schema:domainIncludes schema:Vehicle .
 
 
@@ -12603,12 +12612,12 @@ schema:video rdfs:label "video"@en ;
                                   schema:VideoObject .
 
 
-schema:videoFormat schema:domainIncludes schema:BroadcastEvent ;
-                   schema:rangeIncludes schema:Text ;
-                   schema:domainIncludes schema:ScreeningEvent ;
+schema:videoFormat schema:rangeIncludes schema:Text ;
+                   schema:domainIncludes schema:BroadcastEvent ,
+                                         schema:ScreeningEvent ;
                    rdfs:comment "The type of screening or video broadcast used (e.g. IMAX, 3D, SD, HD, etc.)."@en ;
-                   schema:domainIncludes schema:BroadcastService ;
-                   rdfs:label "videoFormat"@en .
+                   rdfs:label "videoFormat"@en ;
+                   schema:domainIncludes schema:BroadcastService .
 
 
 schema:videoFrameSize schema:domainIncludes schema:VideoObject ;
@@ -12632,10 +12641,10 @@ schema:warranty rdfs:label "warranty"@en ;
 
 schema:warrantyPromise schema:domainIncludes schema:BuyAction ,
                                              schema:SellAction ;
-                       rdfs:label "warrantyPromise"@en ;
-                       schema:rangeIncludes schema:WarrantyPromise ;
                        schema:supersededBy schema:warranty ;
-                       rdfs:comment "The warranty promise(s) included in the offer."@en .
+                       rdfs:comment "The warranty promise(s) included in the offer."@en ;
+                       schema:rangeIncludes schema:WarrantyPromise ;
+                       rdfs:label "warrantyPromise"@en .
 
 
 schema:warrantyScope schema:domainIncludes schema:WarrantyPromise ;
@@ -12667,8 +12676,8 @@ schema:width schema:domainIncludes schema:Product ,
 
 
 schema:wordCount rdfs:comment "The number of words in the text of the Article."@en ;
-                 schema:rangeIncludes schema:Integer ;
                  rdfs:label "wordCount"@en ;
+                 schema:rangeIncludes schema:Integer ;
                  schema:domainIncludes schema:Article .
 
 
@@ -12686,9 +12695,9 @@ schema:workHours rdfs:label "workHours"@en ;
                  schema:domainIncludes schema:JobPosting .
 
 
-schema:worstRating schema:rangeIncludes schema:Text ;
+schema:worstRating schema:rangeIncludes schema:Number ,
+                                        schema:Text ;
                    rdfs:comment "The lowest value allowed in this rating system. If worstRating is omitted, 1 is assumed."@en ;
-                   schema:rangeIncludes schema:Number ;
                    schema:domainIncludes schema:Rating ;
                    rdfs:label "worstRating"@en .
 
@@ -12710,8 +12719,8 @@ schema:yearlyRevenue rdfs:comment "The size of the business in annual revenue."@
 
 schema:yearsInOperation schema:domainIncludes schema:BusinessAudience ;
                         schema:rangeIncludes schema:QuantitativeValue ;
-                        rdfs:label "yearsInOperation"@en ;
-                        rdfs:comment "The age of the business."@en .
+                        rdfs:comment "The age of the business."@en ;
+                        rdfs:label "yearsInOperation"@en .
 
 
 <http://schema.org/docs/schema_org_rdfa.html> dc:source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#IIT-CNR.it> ,


### PR DESCRIPTION
Hi,

This PR brings an enrichment of the mapping (needed for generating JSON-LD snippets about lodging businesses). We also decided to a use a better prefix for data IRIs.

The second aspect regards some advanced features of query logging:
  1. HTTP headers: now any HTTP header can be logged. One just needs to explicit it in the properties. Here we enabled logging the `Referer` header.  By default, `Client-App` and `Prepared-Query` (both non-standard) are logged.
 2. Query template detection and decomposition: after translating the SPARQL query into our internal data structure, we extract the constants (ground terms in general) and we replaced them by variables. We then compute the hash of the query string after applying such a replacement and we log the pairs variable-constant as parameters. The process is deterministic, so 2 queries having the same structure but different parameter values are expected to have the same hash.


Here is an example of the new fields:

```json
{
  "@timestamp": "2020-07-28T10:13:24.977Z",
  "message": "query:reformulated",
  ...
  "payload": {
  ...
    "httpHeaders": {
      "referer": "http://localhost:8080/"
    },
    "extractedQueryTemplate": {
      "hash": "99a2141a87bf443e77e6b03c7fc795c60da8028d1eaa10f8490f65f1658631dd",
      "parameters": {
        "v4": "<http://noi.example.org/data/accommodation/745EB990148B974EBB057DF103E5D7D3>",
        "v5": "\"en\""
      }
    },
   ...
  }
}

```

