### PR TITLE
VKG for mobility data (guests)

### DIFF
--- a/vkg/mobility/catalog-v001.xml
+++ b/vkg/mobility/catalog-v001.xml
@@ -4,14 +4,15 @@
     <uri id="Imports Wizard Entry" name="http://www.ontology-of-units-of-measure.org/resource/om-2/" uri="library/om2.ttl"/>
     <uri id="User Entered Import Resolution" name="http://purl.org/dc/elements/1.1/" uri="library/dublin_core_elements.ttl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1597617111986" name="http://ex.org/suedtirol" uri="mobility.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1597617111986" name="http://schema.org/" uri="library/schemaorg.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1597617111986" name="http://www.opengis.net/ont/geosparql" uri="library/geosparql.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1597617111986" name="http://www.opengis.net/ont/gml" uri="library/gml.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1597617111986" name="http://www.opengis.net/ont/sf" uri="library/sf.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1597617111986" name="http://www.w3.org/2004/02/skos/core" uri="library/core.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1597617111986" name="http://www.w3.org/ns/sosa/" uri="library/sosa.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1597617111986" name="http://www.w3.org/ns/ssn/" uri="library/ssn.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1597617111986" name="shadowed:http://ex.org/suedtirol" uri="library/suedtirol.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1602764558456" name="http://ex.org" uri="test.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1602764558456" name="http://ex.org/suedtirol" uri="mobility.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1602764558456" name="http://schema.org/" uri="library/schemaorg.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1602764558456" name="http://www.opengis.net/ont/geosparql" uri="library/geosparql.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1602764558456" name="http://www.opengis.net/ont/gml" uri="library/gml.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1602764558456" name="http://www.opengis.net/ont/sf" uri="library/sf.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1602764558456" name="http://www.w3.org/2004/02/skos/core" uri="library/core.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1602764558456" name="http://www.w3.org/ns/sosa/" uri="library/sosa.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1602764558456" name="http://www.w3.org/ns/ssn/" uri="library/ssn.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1602764558456" name="shadowed:http://ex.org/suedtirol" uri="library/suedtirol.owl"/>
     </group>
 </catalog>

--- a/vkg/mobility/mobility.properties
+++ b/vkg/mobility/mobility.properties
@@ -1,6 +1,6 @@
-#Thu Aug 27 17:52:30 CEST 2020
+#Sun Oct 04 21:24:21 CEST 2020
 jdbc.url=jdbc\:postgresql\://localhost\:5432/mobility
 jdbc.driver=org.postgresql.Driver
 jdbc.user=xiao
-jdbc.name=529d2b79-baa1-4430-aab0-b0a77aa931c9
+jdbc.name=24c5ed0e-6b6b-445b-adf5-c2ad2acc06ca
 jdbc.password=

--- a/vkg/mobility/mobility_guest.obda
+++ b/vkg/mobility/mobility_guest.obda
@@ -36,8 +36,35 @@ target		:property/{id} a sosa:ObservableProperty ; rdfs:label {cname}^^xsd:strin
 source		SELECT * FROM intimev2.type
 
 mappingId	measurement_observation
-target		:latest_observation/{id} a :LatestObservation ; sosa:resultTime {timestamp} ; sosa:hasSimpleResult {double_value}^^xsd:double ; sosa:observedProperty :property/{type_id} ; sosa:madeBySensor :station/{station_id} .
-source		SELECT * FROM intimev2.measurement
+target		:latest_observation/{me_id} a :LatestObservation ; sosa:resultTime {timestamp} ; sosa:hasSimpleResult {double_value}^^xsd:double ; sosa:observedProperty :property/{type_id} ; sosa:madeBySensor :station/{station_id} .
+source		SELECT me.id AS me_id, timestamp, double_value, type_id, station_id FROM intimev2.station s, intimev2.measurement me
+            WHERE s.id = me.station_id AND
+                  (
+                    -- station types that are always open, regardless of the origin
+                            s.stationtype in (
+                                              'NOI-Place',
+                                              'CreativeIndustry',
+                                              'BluetoothStation',
+                                              'CarpoolingHub',
+                                              'CarpoolingService',
+                                              'CarpoolingUser',
+                                              'CarsharingCar',
+                                              'CarsharingStation',
+                                              'EChargingPlug',
+                                              'EChargingStation',
+                                              'Streetstation',
+                                              'Culture')
+                        -- station types that are only partly open, constrained by the origin
+                        or (s.stationtype = 'Bicycle' and s.origin in ('ALGORAB', 'BIKE_SHARING_MERANO'))
+                        or (s.stationtype = 'BikesharingStation' and s.origin = 'ALGORAB')
+                        or (s.stationtype = 'EnvironmentStation' and s.origin = 'APPATN-open')
+                        or (s.stationtype = 'LinkStation' and (s.origin is null or s.origin = 'NOI'))
+                        or (s.stationtype = 'MeteoStation' and s.origin in ('meteotrentino', 'SIAG'))
+                        or (s.stationtype = 'ParkingStation' and s.origin in ('FAMAS', 'FBK', 'Municipality Merano'))
+                        or (s.stationtype = 'RWISstation' and s.origin = 'InfoMobility')
+                        -- special rules
+                        or (s.origin = 'APPABZ' and me.period = 3600)
+                    )
 
 mappingId	road_segment
 target		:road_segment/{id} a :RoadSegment ; :hasOriginStation :station/{origin_id} ; :hasDestinationStation :station/{destination_id} .
@@ -168,7 +195,35 @@ target		:station/{station_id} :hasStationMetadata {json}^^xsd:string .
 source		SELECT * FROM intimev2.metadata
 
 mappingId	measurement_history_observation
-target		:observation/{id} a sosa:Observation ; sosa:resultTime {timestamp} ; sosa:hasSimpleResult {double_value}^^xsd:double ; sosa:observedProperty :property/{type_id} ; sosa:madeBySensor :station/{station_id} .
-source		SELECT * FROM intimev2.measurementhistory
+target		:observation/{me_id} a sosa:Observation ; sosa:resultTime {timestamp} ; sosa:hasSimpleResult {double_value}^^xsd:double ; sosa:observedProperty :property/{type_id} ; sosa:madeBySensor :station/{station_id} .
+source		SELECT me.id AS me_id, timestamp, double_value, type_id, station_id FROM intimev2.station s, intimev2.measurementhistory me
+            WHERE s.id = me.station_id AND
+                (
+                    -- station types that are always open, regardless of the origin
+                            s.stationtype in (
+                                              'NOI-Place',
+                                              'CreativeIndustry',
+                                              'BluetoothStation',
+                                              'CarpoolingHub',
+                                              'CarpoolingService',
+                                              'CarpoolingUser',
+                                              'CarsharingCar',
+                                              'CarsharingStation',
+                                              'EChargingPlug',
+                                              'EChargingStation',
+                                              'Streetstation',
+                                              'Culture')
+                        -- station types that are only partly open, constrained by the origin
+                        or (s.stationtype = 'Bicycle' and s.origin in ('ALGORAB', 'BIKE_SHARING_MERANO'))
+                        or (s.stationtype = 'BikesharingStation' and s.origin = 'ALGORAB')
+                        or (s.stationtype = 'EnvironmentStation' and s.origin = 'APPATN-open')
+                        or (s.stationtype = 'LinkStation' and (s.origin is null or s.origin = 'NOI'))
+                        or (s.stationtype = 'MeteoStation' and s.origin in ('meteotrentino', 'SIAG'))
+                        or (s.stationtype = 'ParkingStation' and s.origin in ('FAMAS', 'FBK', 'Municipality Merano'))
+                        or (s.stationtype = 'RWISstation' and s.origin = 'InfoMobility')
+                        -- special rules
+                        or (s.origin = 'APPABZ' and me.period = 3600)
+                    )
+            ;
 ]]
 


### PR DESCRIPTION
This PR contains the VKG specification of Mobility data. There are two obda mapping files, one with full permission, and another will guest permission.

These files are still currently in a separate folder. In the future, they will be merged together will the tourism data.