### PR TITLE
Automatically restart nginx and oauth2-proxy

### DIFF
--- a/docker-compose.auth.yml
+++ b/docker-compose.auth.yml
@@ -88,6 +88,7 @@ services:
   oauth2:
     image: quay.io/oauth2-proxy/oauth2-proxy:v7.0.1
     env_file: .env
+    restart: unless-stopped
     command: [
         "--provider=oidc",
         "--oidc-issuer-url=${KEYCLOAK_REALM_URL}",
@@ -123,6 +124,7 @@ services:
       context: ./
       dockerfile: infrastructure/docker/nginx/Dockerfile
     env_file: .env
+    restart: unless-stopped
     ports:
       - "${SERVER_PORT}:80"
   tourism-master-db:

--- a/infrastructure/docker-compose.run.yml
+++ b/infrastructure/docker-compose.run.yml
@@ -52,6 +52,7 @@ services:
       - "${SERVER_PORT}:80"
   oauth2:
     image: quay.io/oauth2-proxy/oauth2-proxy:v7.0.1
+    restart: unless-stopped
     env_file: .env
     command:
       [


### PR DESCRIPTION
This trivial patch enables automatic restart for the nginx and oauth2-proxy containers.
This should solve transient failure situation where the crash of oauth2-proxy would in turn crash the nginx container.
