### PR TITLE
Temporary mapping update for putting the test server up again

### DIFF
--- a/sql/public/V7__geometry_columns.sql
+++ b/sql/public/V7__geometry_columns.sql
@@ -7,13 +7,13 @@ CREATE INDEX v_accommodationsopen_geom_idx
     ON v_accommodationsopen
         USING GIST ("Geometry");
 
-ALTER TABLE v_poisopen
+ALTER TABLE "v_poisopen_Gpsinfo"
     add "Geometry" geometry GENERATED ALWAYS AS (
-        ST_SetSRID(ST_MakePoint("GpsPoints-position-Longitude", "GpsPoints-position-Latitude"),4326))
+        ST_SetSRID(ST_MakePoint("Longitude", "Latitude"),4326))
         STORED ;
 
 CREATE INDEX v_poisopen_geom_idx
-    ON v_poisopen
+    ON "v_poisopen_Gpsinfo"
         USING GIST ("Geometry");
 
 ALTER TABLE v_skiareasopen

--- a/vkg/odh.obda
+++ b/vkg/odh.obda
@@ -27,24 +27,23 @@ source		SELECT "Id"
 			WHERE "AccoTypeId" = 'Camping'
 
 mappingId	LodgingBusiness
-target		odh:lodging-businesses/{id} a schema:LodgingBusiness ; schema:email {de_email} ; schema:name {de_name}@de , {it_name}@it , {en_name}@en ; schema:telephone {de_phone} ; schema:faxNumber {de_fax} ; schema:description {it_desc}@it , {de_desc}@de , {en_desc}@en ; schema:alternateName {de_add_name}@de , {en_add_name}@en , {it_add_name}@it ; schema:url <{url}> ; schema:starRating data:category/accommodation/{id}/{rating} ; sioc:has_container <https://kg.opendatahub.bz.it/lodging-businesses/> .
-source		SELECT "Id" AS id, NULLIF("AccoDetail-de-Email", '') AS de_email, "AccoDetail-de-Name" AS de_name,  "AccoDetail-en-Name" AS en_name, "AccoDetail-it-Name" AS it_name, "AccoDetail-de-Phone" AS de_phone,
-			"AccoDetail-de-Fax" AS  de_fax, "AccoDetail-it-Shortdesc" AS it_desc,  "AccoDetail-de-Shortdesc" AS de_desc,  "AccoDetail-en-Shortdesc" AS en_desc, "AccoDetail-de-NameAddition" AS de_add_name, "AccoDetail-en-NameAddition" as en_add_name,  "AccoDetail-it-NameAddition" as it_add_name, "AccoCategoryId" as rating, "AccoDetail-de-Website" AS url
+target		odh:lodging-businesses/{id} a schema:LodgingBusiness ; schema:name {de_name}@de , {it_name}@it , {en_name}@en ; schema:telephone {de_phone} ; schema:url <{url}> ; schema:starRating data:category/accommodation/{id}/{rating} ; sioc:has_container <https://kg.opendatahub.bz.it/lodging-businesses/> .
+source		SELECT "Id" AS id, "AccoDetail-de-Name" AS de_name,  "AccoDetail-en-Name" AS en_name, "AccoDetail-it-Name" AS it_name, "AccoDetail-de-Phone" AS de_phone,
+			"AccoCategoryId" as rating, "AccoDetail-de-Website" AS url
 			FROM "v_accommodationsopen"
 
 mappingId	Lodging business - geo
-target		data:geo/accommodation/{id} a schema:GeoCoordinates , geo:Geometry ; schema:latitude {latitude} ; schema:elevation {altitude} ; schema:longitude {longitude} ; geo:asWKT {wkt}^^geo:wktLiteral . odh:lodging-businesses/{id} schema:geo data:geo/accommodation/{id} ; geo:defaultGeometry data:geo/accommodation/{id} .
-source		SELECT "Id" AS id, "Latitude" AS latitude, "Longitude" AS longitude, "Altitude" AS altitude, ST_AsText("Geometry") AS wkt
+target		data:geo/accommodation/{id} a schema:GeoCoordinates , geo:Geometry ; schema:latitude {latitude} ; schema:elevation {altitude} ; schema:longitude {longitude} . odh:lodging-businesses/{id} schema:geo data:geo/accommodation/{id} ; geo:defaultGeometry data:geo/accommodation/{id} .
+source		SELECT "Id" AS id, "Latitude" AS latitude, "Longitude" AS longitude, "Altitude" AS altitude
 			FROM "v_accommodationsopen"
 
 mappingId	LodgingBusiness - address
-target		data:address/accommodation/{id} a schema:PostalAddress ; schema:name {de_name}@de , {it_name}@it , {en_name}@en ; schema:alternateName {de_add_name}@de , {en_add_name}@en , {it_add_name}@it ; schema:streetAddress {de_street}@de , {it_street}@it , {en_street}@en ; schema:postalCode {de_zip} ; schema:addressLocality {de_city}@de , {it_city}@it , {en_city}@en . odh:lodging-businesses/{id} schema:address data:address/accommodation/{id} .
+target		data:address/accommodation/{id} a schema:PostalAddress ; schema:name {de_name}@de , {it_name}@it , {en_name}@en ; schema:streetAddress {de_street}@de , {it_street}@it , {en_street}@en ; schema:postalCode {de_zip} ; schema:addressLocality {de_city}@de , {it_city}@it , {en_city}@en . odh:lodging-businesses/{id} schema:address data:address/accommodation/{id} .
 source		SELECT "Id" AS id,
 			"AccoDetail-de-City" AS de_city, "AccoDetail-de-Zip" AS de_zip, "AccoDetail-de-Street" AS de_street,
 			"AccoDetail-it-City" AS it_city, "AccoDetail-it-Street" AS it_street,
 			"AccoDetail-en-City" AS en_city, "AccoDetail-en-Street" AS en_street,
-			"AccoDetail-de-Name" AS de_name,  "AccoDetail-en-Name" AS en_name, "AccoDetail-it-Name" AS it_name, "AccoDetail-de-Phone" AS phone, "AccoDetail-de-Mobile"  AS mobile, "AccoDetail-de-Fax" AS fax,
-			"AccoDetail-de-NameAddition" AS de_add_name, "AccoDetail-en-NameAddition" as en_add_name,  "AccoDetail-it-NameAddition" as it_add_name,   "AccoDetail-de-Email" AS email
+			"AccoDetail-de-Name" AS de_name,  "AccoDetail-en-Name" AS en_name, "AccoDetail-it-Name" AS it_name, "AccoDetail-de-Phone" AS phone
 			FROM "v_accommodationsopen"
 
 mappingId	PensionHotel
@@ -73,37 +72,10 @@ mappingId	Area
 target		odh:areas/{Id} a schema:AdministrativeArea ; rdfs:label {Shortname}^^xsd:string ; schema:name {Shortname}^^xsd:string ; sioc:has_container <https://kg.opendatahub.bz.it/areas/> .
 source		SELECT "Id", "Shortname" FROM v_areas
 
-mappingId	POI_Area
-target		data:poi/{Id} schema:isPartOf odh:areas/{data} .
-source		SELECT "Id", "data" FROM "v_poisopen_AreaId";
-
 mappingId	POI-geo
-target		data:poi/{Id} schema:geo data:geo/poi/{Id} ; geo:defaultGeometry data:geo/poi/{Id} . data:geo/poi/{Id} a schema:GeoCoordinates, geo:Geometry ; schema:longitude {GpsPoints-position-Longitude} ; schema:latitude {GpsPoints-position-Latitude} ; schema:elevation {GpsPoints-position-Altitude} ; geo:asWKT {wkt}^^geo:wktLiteral.
-source		SELECT "Id", "Shortname", "GpsPoints-position-Latitude", "GpsPoints-position-Longitude", "GpsPoints-position-Altitude", ST_AsText("Geometry") AS wkt FROM v_poisopen
+target         data:poi/{poisopen_Id} schema:geo data:geo/poi/{poisopen_Id} ; geo:defaultGeometry data:geo/poi/{poisopen_Id} . data:geo/poi/{poisopen_Id} a schema:GeoCoordinates, geo:Geometry ; schema:longitude {Longitude} ; schema:latitude {Latitude} ; schema:elevation {Altitude} .
+source         SELECT * FROM "v_poisopen_GpsInfo"
 
-mappingId	Accommodation
-target		data:room/{Id} a schema:Accommodation ; schema:containedInPlace odh:lodging-businesses/{A0RID} ; schema:name {AccoRoomDetail-it-Name}@it , {AccoRoomDetail-en-Name}@en , {AccoRoomDetail-de-Name}@de ; :numberOfUnits {RoomQuantity} ; schema:occupancy data:occupancy/room/{Id} .
-source		SELECT "Id", "A0RID", "AccoRoomDetail-en-Name", "AccoRoomDetail-de-Name", "AccoRoomDetail-it-Name", "RoomQuantity" FROM v_accommodationroomsopen
-
-mappingId	Room
-target		data:room/{Id} a schema:Room .
-source		SELECT "Id" FROM v_accommodationroomsopen
-			WHERE "Roomtype" = 'room'
-
-mappingId	Apartment
-target		data:room/{Id} a schema:Apartment .
-source		SELECT "Id" FROM v_accommodationroomsopen
-			WHERE "Roomtype" = 'apartment'
-
-mappingId	Camping pitch
-target		data:room/{Id} a schema:CampingPitch .
-source		SELECT "Id" FROM v_accommodationroomsopen
-			WHERE "Roomtype" = 'pitch' OR "Roomtype" = 'campsite'
-
-mappingId	Room occupancy
-target		data:occupancy/room/{Id} a schema:QuantitativeValue ; schema:minValue {Roommin} ; schema:maxValue {Roommax} ; schema:unitCode "C62"^^xsd:string .
-source		SELECT "Id", "Roommin", "Roommax"
-			FROM v_accommodationroomsopen
 
 mappingId	Event EURAC NOI
 target		odh:events/euracnoi/{Id} a schema:Event ; schema:startDate {StartDate}^^xsd:dateTime ; schema:endDate {EndDate}^^xsd:dateTime ; schema:name {EventDescriptionIT}@it , {EventDescriptionDE}@de , {EventDescriptionEN}@en ; schema:description {EventDescriptionIT}@it , {EventDescriptionDE}@de , {EventDescriptionEN}@en ; schema:location data:location/euracnoi/{EventLocation}/{AnchorVenue} ; schema:organizer data:organization/event/euracnoi/{Id} , data:contact/event/euracnoi/{Id} ; sioc:has_container <https://kg.opendatahub.bz.it/events/> .
@@ -130,27 +102,22 @@ target		data:address/organization/event/euracnoi/{Id} a schema:PostalAddress ; s
 source		select "Id", "CompanyAddressLine1", "CompanyCity", "CompanyCountry", "CompanyPostalCode"
 			from v_eventeuracnoi
 
-mappingId	Caravan pitch
-target		data:room/{Id} a :CaravanPitch .
-source		SELECT "Id" FROM v_accommodationroomsopen
-			WHERE "Roomtype" = 'caravan'
-
 mappingId	SkiResort
 target		odh:ski-resorts/{Id} a schema:SkiResort ; rdfs:label {Detail-en-Header}^^xsd:string ; schema:name {Detail-en-Header}^^xsd:string  ; schema:image <{SkiAreaMapURL}> ; schema:isPartOf odh:ski-regions/{SkiRegionId} ; schema:geo data:geo/skiResort/{Id} ; geo:defaultGeometry data:geo/skiResort/{Id} ; sioc:has_container <https://kg.opendatahub.bz.it/ski-resorts/> .
-source		SELECT "Id", "Shortname", "Detail-en-Header", ST_AsText("Geometry") AS wkt, "SkiAreaMapURL", "SkiRegionId" FROM v_skiareasopen
+source		SELECT "Id", "Shortname", "Detail-en-Header", "SkiAreaMapURL", "SkiRegionId" FROM v_skiareasopen
 
 mappingId	SkiResort - geo
-target		data:geo/skiResort/{id} a schema:GeoCoordinates , geo:Geometry ; schema:latitude {latitude} ; schema:longitude {longitude} ; schema:elevation {AltitudeTo}; geo:asWKT {wkt}^^geo:wktLiteral . odh:ski-resorts/{id} schema:geo data:geo/skiResort/{id} ; geo:defaultGeometry data:geo/skiResort/{id} .
-source		SELECT "Id" AS id, "Latitude" AS latitude, "Longitude" AS longitude, "AltitudeTo" AS AltitudeTo, ST_AsText("Geometry") AS wkt
+target		data:geo/skiResort/{id} a schema:GeoCoordinates , geo:Geometry ; schema:latitude {latitude} ; schema:longitude {longitude} ; schema:elevation {AltitudeTo} . odh:ski-resorts/{id} schema:geo data:geo/skiResort/{id} ; geo:defaultGeometry data:geo/skiResort/{id} .
+source		SELECT "Id" AS id, "Latitude" AS latitude, "Longitude" AS longitude, "AltitudeTo" AS AltitudeTo
 			FROM "v_skiareasopen"
 
 mappingId	SkiRegion
 target		odh:ski-regions/{Id} a :SkiRegion ; rdfs:label {Shortname}^^xsd:string ; schema:name {Shortname}^^xsd:string  ; schema:elevation {Altitude}^^xsd:decimal .
-source		SELECT "Id", "Shortname", ST_AsText("Geometry") AS wkt, "Altitude" FROM v_skiregionsopen
+source		SELECT "Id", "Shortname", "Altitude" FROM v_skiregionsopen
 
 mappingId	SkiRegion - geo
-target		data:geo/skiRegion/{id} a schema:GeoCoordinates , geo:Geometry ; schema:latitude {latitude} ; schema:longitude {longitude} ; geo:asWKT {wkt}^^geo:wktLiteral . odh:ski-regions/{id} schema:geo data:geo/skiRegion/{id} ; geo:defaultGeometry data:geo/skiResort/{id} .
-source		SELECT "Id" AS id, "Latitude" AS latitude, "Longitude" AS longitude, "Altitude" AS altitude, ST_AsText("Geometry") AS wkt
+target		data:geo/skiRegion/{id} a schema:GeoCoordinates , geo:Geometry ; schema:latitude {latitude} ; schema:longitude {longitude} . odh:ski-regions/{id} schema:geo data:geo/skiRegion/{id} ; geo:defaultGeometry data:geo/skiResort/{id} .
+source		SELECT "Id" AS id, "Latitude" AS latitude, "Longitude" AS longitude, "Altitude" AS altitude
 			FROM "v_skiregionsopen"
 
 mappingId	SkiResort_Area
@@ -184,12 +151,12 @@ source		select "EventLocation"
 			from v_eventeuracnoi
 
 mappingId	Food establishments
-target		odh:food-establishments/{Id} a schema:FoodEstablishment ; schema:name {Detail-de-Title}@de , {Detail-it-Title}@it , {Detail-en-Title}@en ; schema:description {Detail-de-BaseText}@de , {Detail-it-BaseText}@it , {Detail-en-BaseText}@en ; schema:geo data:geo/gastronomy/{Id} ; geo:defaultGeometry data:geo/gastronomy/{Id} ; schema:address data:address/gastronomy/{Id} ; schema:telephone {ContactInfos-de-Phonenumber} ; schema:hasMenu data:menu/gastronomy/{Id} ; sioc:has_container <https://kg.opendatahub.bz.it/food-establishments/> .
+target		odh:food-establishments/{Id} a schema:FoodEstablishment ; schema:name {Detail-de-Title}@de , {Detail-it-Title}@it , {Detail-en-Title}@en ; schema:geo data:geo/gastronomy/{Id} ; geo:defaultGeometry data:geo/gastronomy/{Id} ; schema:address data:address/gastronomy/{Id} ; schema:telephone {ContactInfos-de-Phonenumber} ; schema:hasMenu data:menu/gastronomy/{Id} ; sioc:has_container <https://kg.opendatahub.bz.it/food-establishments/> .
 source		SELECT * FROM v_gastronomiesopen
 
 mappingId	Food establishments - geo
-target		data:geo/gastronomy/{Id} a schema:GeoCoordinates , geo:Geometry ; schema:latitude {Latitude} ; schema:elevation {Altitude} ; schema:longitude {Longitude} ; geo:asWKT {wkt}^^geo:wktLiteral .
-source		SELECT *, ST_AsText("Geometry") AS wkt FROM v_gastronomiesopen
+target		data:geo/gastronomy/{Id} a schema:GeoCoordinates , geo:Geometry ; schema:latitude {Latitude} ; schema:elevation {Altitude} ; schema:longitude {Longitude} .
+source		SELECT * FROM v_gastronomiesopen
 
 mappingId	Food establishments - address
 target		data:address/gastronomy/{Id} a schema:PostalAddress ; schema:streetAddress {ContactInfos-de-Address}@de , {ContactInfos-it-Address}@it , {ContactInfos-en-Address}@en ; schema:postalCode {ContactInfos-de-ZipCode} ; schema:addressLocality {ContactInfos-de-City}@de , {ContactInfos-it-City}@it , {ContactInfos-en-City}@en .
@@ -275,37 +242,13 @@ source		SELECT *
 			FROM "v_gastronomiesopen_CategoryCodes"
 			WHERE "Shortname" = 'Braugarten'
 
-mappingId	Asian cuisine
-target		odh:food-establishments/{Id} schema:servesCuisine "asian"@en , "asiatisch"@de , "asiatica"@it .
-source		SELECT "Id", "Detail-it-BaseText", "Detail-de-BaseText"
-			FROM "v_gastronomiesopen"
-			WHERE "Detail-it-BaseText" like '%asiat%' OR "Detail-de-BaseText" like '%asiat%'
-
-mappingId	Mediterranean cuisine
-target		odh:food-establishments/{Id} schema:servesCuisine "mediterranean"@en , "mediterrane"@de , "mediterranea"@it .
-source		SELECT "Id", "Detail-it-BaseText", "Detail-de-BaseText"
-			FROM "v_gastronomiesopen"
-			WHERE "Detail-it-BaseText" like '%mediterra%' OR "Detail-de-BaseText" like '%mediterra%'
-
-mappingId	Apfelstrudel
-target		data:menu/gastronomy/{Id} schema:hasMenuItem data:menuitem/apfelstrudel/{Id} . data:menuitem/apfelstrudel/{Id} schema:name "Apfelstrudel"@de , "strudel di mela"@it , "Apfelstrudel"@en .
-source		SELECT "Id"
-			FROM public.v_gastronomiesopen
-			WHERE "Detail-de-BaseText" ~ 'Apfelstrudel'
-
 mappingId	Lodging Business - aggregate rating
-target		data:rating/trustyou/{id}/{trustId} a schema:AggregateRating ; schema:author data:author/trustyou ; schema:bestRating "100"^^xsd:integer ; schema:ratingValue {score}^^xsd:integer ; schema:reviewCount {reviews}^^xsd:integer .
-source		select "Id" as id, "TrustYouID" as trustId, "TrustYouScore"/10 as  score , "TrustYouResults" as reviews from "v_accommodationsopen" where "TrustYouActive"=true and "TrustYouScore" > 0
+target		data:rating/trustyou/{id} a schema:AggregateRating ; schema:author data:author/trustyou ; schema:bestRating "100"^^xsd:integer ; schema:ratingValue {score}^^xsd:integer ; schema:reviewCount {reviews}^^xsd:integer .
+source		select "Id" as id, "TrustYouScore"/10 as  score , "TrustYouResults" as reviews from "v_accommodationsopen" where "TrustYouActive"=true and "TrustYouScore" > 0
 
 mappingId	Lodging Business -hasAggregateRating
-target		odh:lodging-businesses/{id} schema:aggregateRating data:rating/trustyou/{id}/{trustId} .
-source		select "Id" as id, "TrustYouID" as trustId from "v_accommodationsopen" where "TrustYouActive"=true and "TrustYouScore" > 0
-
-mappingId	Lodging Business - image
-target		odh:lodging-businesses/{id} schema:image <{image}> .
-source		select  "accommodationsopen_Id" as id , "ImageUrl" as image from "v_accommodationsopen_ImageGallery" where
-			( ("ValidTo" IS NULL OR "ValidTo" !~ '(?:(\d\d\d\d)-(0[1-9]|10|11|12)-([0-2]\d|30|31))T(([01]\d|2[0-3])(?:\:([0-5]\d)(?::([0-5]\d))))') OR (TO_TIMESTAMP("ValidTo", 'YYYY-MM-DDTHH24:MI:SS') > NOW()  ) )
-			AND (("ValidFrom" IS NULL OR "ValidFrom" !~ '(?:(\d\d\d\d)-(0[1-9]|10|11|12)-([0-2]\d|30|31))T(([01]\d|2[0-3])(?:\:([0-5]\d)(?::([0-5]\d))))') OR (TO_TIMESTAMP("ValidFrom", 'YYYY-MM-DDTHH24:MI:SS') < NOW()))
+target		odh:lodging-businesses/{id} schema:aggregateRating data:rating/trustyou/{id} .
+source		select "Id" as id from "v_accommodationsopen" where "TrustYouActive"=true and "TrustYouScore" > 0
 
 mappingId	MAPID-9dbd9116f9f84c78961099f0004a9690
 target		data:author/trustyou a schema:Organization ; schema:name "Trust you"^^xsd:string ; schema:url <https://www.trustyou.com/> .
@@ -318,10 +261,6 @@ source		select "Id" as id,  "AccoCategoryId" as rating, (CASE WHEN "AccoCategory
 mappingId	Price range
 target		odh:lodging-businesses/{id} schema:priceRange {value}^^xsd:string .
 source		select "Id" as id,  (CASE WHEN "AccoCategoryId" = '1flowers' or "AccoCategoryId" = '1stars'  or "AccoCategoryId" = '1suns' or "AccoCategoryId" = '2flowers' or "AccoCategoryId" = '2stars'  or "AccoCategoryId" = '2suns'   THEN '€'  WHEN "AccoCategoryId" = '3flowers' or "AccoCategoryId" = '3stars'  or "AccoCategoryId" = '3suns' or "AccoCategoryId" = '3sstars'  THEN '€€'  WHEN "AccoCategoryId" = '4flowers' or "AccoCategoryId" = '4stars'  or "AccoCategoryId" = '4suns'   THEN '€€€'  WHEN "AccoCategoryId" = '4sstars' or "AccoCategoryId" = '5flowers' or "AccoCategoryId" = '5stars'  or "AccoCategoryId" = '5suns' THEN '€€€€' ELSE NULL END ) as value FROM "v_accommodationsopen"
-
-mappingId	Lodging Business - image rank
-target		<{image}> :rankingValue {rankValue}^^xsd:integer .
-source		select  "ImageUrl" as image, "ListPosition" as rankValue  from "v_accommodationsopen_ImageGallery"
 
 mappingId	road_segment_geom
 target		data:road_segment/{id} geo:defaultGeometry data:road_segment/geometry/{id} . data:road_segment/geometry/{id} geo:asWKT {wkt}^^geo:wktLiteral .
@@ -846,10 +785,6 @@ mappingId	metadata
 target		data:station/{station_id} :hasStationMetadata {json}^^xsd:string .
 source		SELECT * FROM intimev2.metadata
 
-mappingId	municipality_geom
-target		odh:municipalities/0{istat_code} geo:defaultGeometry odh:municipalities/geometry/0{istat_code} . odh:municipalities/geometry/0{istat_code} geo:asWKT {wkt}^^geo:wktLiteral .
-source		SELECT istat_code, ST_AsText(geom_4326) AS wkt FROM odp_municipalities
-
 mappingId	LodgingBusiness-municipality
 target		odh:lodging-businesses/{Id} schema:containedInPlace odh:municipalities/{IstatNumber} . 
 source		SELECT a."Id", m."IstatNumber" FROM "v_accommodationsopen" a, "v_municipalitiesopen" m WHERE a."LocationInfo-MunicipalityInfo-Id" = m."Id" 
@@ -897,5 +832,4 @@ source		SELECT * FROM intimev2.type WHERE id IN (8)
 mappingId	Nitrogen-dioxide concentration
 target		data:property/{id} a :NitrogenDioxideConcentration .
 source		SELECT * FROM intimev2.type WHERE id IN (12)
-
 ]]

--- a/vkg/odh_guest.obda
+++ b/vkg/odh_guest.obda
@@ -27,24 +27,23 @@ source		SELECT "Id"
 			WHERE "AccoTypeId" = 'Camping'
 
 mappingId	LodgingBusiness
-target		odh:lodging-businesses/{id} a schema:LodgingBusiness ; schema:email {de_email} ; schema:name {de_name}@de , {it_name}@it , {en_name}@en ; schema:telephone {de_phone} ; schema:faxNumber {de_fax} ; schema:description {it_desc}@it , {de_desc}@de , {en_desc}@en ; schema:alternateName {de_add_name}@de , {en_add_name}@en , {it_add_name}@it ; schema:url <{url}> ; schema:starRating data:category/accommodation/{id}/{rating} ; sioc:has_container <https://kg.opendatahub.bz.it/lodging-businesses/> .
-source		SELECT "Id" AS id, NULLIF("AccoDetail-de-Email", '') AS de_email, "AccoDetail-de-Name" AS de_name,  "AccoDetail-en-Name" AS en_name, "AccoDetail-it-Name" AS it_name, "AccoDetail-de-Phone" AS de_phone,
-			"AccoDetail-de-Fax" AS  de_fax, "AccoDetail-it-Shortdesc" AS it_desc,  "AccoDetail-de-Shortdesc" AS de_desc,  "AccoDetail-en-Shortdesc" AS en_desc, "AccoDetail-de-NameAddition" AS de_add_name, "AccoDetail-en-NameAddition" as en_add_name,  "AccoDetail-it-NameAddition" as it_add_name, "AccoCategoryId" as rating, "AccoDetail-de-Website" AS url
+target		odh:lodging-businesses/{id} a schema:LodgingBusiness ; schema:name {de_name}@de , {it_name}@it , {en_name}@en ; schema:telephone {de_phone} ; schema:url <{url}> ; schema:starRating data:category/accommodation/{id}/{rating} ; sioc:has_container <https://kg.opendatahub.bz.it/lodging-businesses/> .
+source		SELECT "Id" AS id, "AccoDetail-de-Name" AS de_name,  "AccoDetail-en-Name" AS en_name, "AccoDetail-it-Name" AS it_name, "AccoDetail-de-Phone" AS de_phone,
+			"AccoCategoryId" as rating, "AccoDetail-de-Website" AS url
 			FROM "v_accommodationsopen"
 
 mappingId	Lodging business - geo
-target		data:geo/accommodation/{id} a schema:GeoCoordinates , geo:Geometry ; schema:latitude {latitude} ; schema:elevation {altitude} ; schema:longitude {longitude} ; geo:asWKT {wkt}^^geo:wktLiteral . odh:lodging-businesses/{id} schema:geo data:geo/accommodation/{id} ; geo:defaultGeometry data:geo/accommodation/{id} .
-source		SELECT "Id" AS id, "Latitude" AS latitude, "Longitude" AS longitude, "Altitude" AS altitude, ST_AsText("Geometry") AS wkt
+target		data:geo/accommodation/{id} a schema:GeoCoordinates , geo:Geometry ; schema:latitude {latitude} ; schema:elevation {altitude} ; schema:longitude {longitude} . odh:lodging-businesses/{id} schema:geo data:geo/accommodation/{id} ; geo:defaultGeometry data:geo/accommodation/{id} .
+source		SELECT "Id" AS id, "Latitude" AS latitude, "Longitude" AS longitude, "Altitude" AS altitude
 			FROM "v_accommodationsopen"
 
 mappingId	LodgingBusiness - address
-target		data:address/accommodation/{id} a schema:PostalAddress ; schema:name {de_name}@de , {it_name}@it , {en_name}@en ; schema:alternateName {de_add_name}@de , {en_add_name}@en , {it_add_name}@it ; schema:streetAddress {de_street}@de , {it_street}@it , {en_street}@en ; schema:postalCode {de_zip} ; schema:addressLocality {de_city}@de , {it_city}@it , {en_city}@en . odh:lodging-businesses/{id} schema:address data:address/accommodation/{id} .
+target		data:address/accommodation/{id} a schema:PostalAddress ; schema:name {de_name}@de , {it_name}@it , {en_name}@en ; schema:streetAddress {de_street}@de , {it_street}@it , {en_street}@en ; schema:postalCode {de_zip} ; schema:addressLocality {de_city}@de , {it_city}@it , {en_city}@en . odh:lodging-businesses/{id} schema:address data:address/accommodation/{id} .
 source		SELECT "Id" AS id,
 			"AccoDetail-de-City" AS de_city, "AccoDetail-de-Zip" AS de_zip, "AccoDetail-de-Street" AS de_street,
 			"AccoDetail-it-City" AS it_city, "AccoDetail-it-Street" AS it_street,
 			"AccoDetail-en-City" AS en_city, "AccoDetail-en-Street" AS en_street,
-			"AccoDetail-de-Name" AS de_name,  "AccoDetail-en-Name" AS en_name, "AccoDetail-it-Name" AS it_name, "AccoDetail-de-Phone" AS phone, "AccoDetail-de-Mobile"  AS mobile, "AccoDetail-de-Fax" AS fax,
-			"AccoDetail-de-NameAddition" AS de_add_name, "AccoDetail-en-NameAddition" as en_add_name,  "AccoDetail-it-NameAddition" as it_add_name,   "AccoDetail-de-Email" AS email
+			"AccoDetail-de-Name" AS de_name,  "AccoDetail-en-Name" AS en_name, "AccoDetail-it-Name" AS it_name, "AccoDetail-de-Phone" AS phone
 			FROM "v_accommodationsopen"
 
 mappingId	PensionHotel
@@ -73,37 +72,10 @@ mappingId	Area
 target		odh:areas/{Id} a schema:AdministrativeArea ; rdfs:label {Shortname}^^xsd:string ; schema:name {Shortname}^^xsd:string ; sioc:has_container <https://kg.opendatahub.bz.it/areas/> .
 source		SELECT "Id", "Shortname" FROM v_areas
 
-mappingId	POI_Area
-target		data:poi/{Id} schema:isPartOf odh:areas/{data} .
-source		SELECT "Id", "data" FROM "v_poisopen_AreaId";
-
 mappingId	POI-geo
-target		data:poi/{Id} schema:geo data:geo/poi/{Id} ; geo:defaultGeometry data:geo/poi/{Id} . data:geo/poi/{Id} a schema:GeoCoordinates, geo:Geometry ; schema:longitude {GpsPoints-position-Longitude} ; schema:latitude {GpsPoints-position-Latitude} ; schema:elevation {GpsPoints-position-Altitude} ; geo:asWKT {wkt}^^geo:wktLiteral.
-source		SELECT "Id", "Shortname", "GpsPoints-position-Latitude", "GpsPoints-position-Longitude", "GpsPoints-position-Altitude", ST_AsText("Geometry") AS wkt FROM v_poisopen
+target         data:poi/{poisopen_Id} schema:geo data:geo/poi/{poisopen_Id} ; geo:defaultGeometry data:geo/poi/{poisopen_Id} . data:geo/poi/{poisopen_Id} a schema:GeoCoordinates, geo:Geometry ; schema:longitude {Longitude} ; schema:latitude {Latitude} ; schema:elevation {Altitude} .
+source         SELECT * FROM "v_poisopen_GpsInfo"
 
-mappingId	Accommodation
-target		data:room/{Id} a schema:Accommodation ; schema:containedInPlace odh:lodging-businesses/{A0RID} ; schema:name {AccoRoomDetail-it-Name}@it , {AccoRoomDetail-en-Name}@en , {AccoRoomDetail-de-Name}@de ; :numberOfUnits {RoomQuantity} ; schema:occupancy data:occupancy/room/{Id} .
-source		SELECT "Id", "A0RID", "AccoRoomDetail-en-Name", "AccoRoomDetail-de-Name", "AccoRoomDetail-it-Name", "RoomQuantity" FROM v_accommodationroomsopen
-
-mappingId	Room
-target		data:room/{Id} a schema:Room .
-source		SELECT "Id" FROM v_accommodationroomsopen
-			WHERE "Roomtype" = 'room'
-
-mappingId	Apartment
-target		data:room/{Id} a schema:Apartment .
-source		SELECT "Id" FROM v_accommodationroomsopen
-			WHERE "Roomtype" = 'apartment'
-
-mappingId	Camping pitch
-target		data:room/{Id} a schema:CampingPitch .
-source		SELECT "Id" FROM v_accommodationroomsopen
-			WHERE "Roomtype" = 'pitch' OR "Roomtype" = 'campsite'
-
-mappingId	Room occupancy
-target		data:occupancy/room/{Id} a schema:QuantitativeValue ; schema:minValue {Roommin} ; schema:maxValue {Roommax} ; schema:unitCode "C62"^^xsd:string .
-source		SELECT "Id", "Roommin", "Roommax"
-			FROM v_accommodationroomsopen
 
 mappingId	Event EURAC NOI
 target		odh:events/euracnoi/{Id} a schema:Event ; schema:startDate {StartDate}^^xsd:dateTime ; schema:endDate {EndDate}^^xsd:dateTime ; schema:name {EventDescriptionIT}@it , {EventDescriptionDE}@de , {EventDescriptionEN}@en ; schema:description {EventDescriptionIT}@it , {EventDescriptionDE}@de , {EventDescriptionEN}@en ; schema:location data:location/euracnoi/{EventLocation}/{AnchorVenue} ; schema:organizer data:organization/event/euracnoi/{Id} , data:contact/event/euracnoi/{Id} ; sioc:has_container <https://kg.opendatahub.bz.it/events/> .
@@ -130,27 +102,22 @@ target		data:address/organization/event/euracnoi/{Id} a schema:PostalAddress ; s
 source		select "Id", "CompanyAddressLine1", "CompanyCity", "CompanyCountry", "CompanyPostalCode"
 			from v_eventeuracnoi
 
-mappingId	Caravan pitch
-target		data:room/{Id} a :CaravanPitch .
-source		SELECT "Id" FROM v_accommodationroomsopen
-			WHERE "Roomtype" = 'caravan'
-
 mappingId	SkiResort
 target		odh:ski-resorts/{Id} a schema:SkiResort ; rdfs:label {Detail-en-Header}^^xsd:string ; schema:name {Detail-en-Header}^^xsd:string  ; schema:image <{SkiAreaMapURL}> ; schema:isPartOf odh:ski-regions/{SkiRegionId} ; schema:geo data:geo/skiResort/{Id} ; geo:defaultGeometry data:geo/skiResort/{Id} ; sioc:has_container <https://kg.opendatahub.bz.it/ski-resorts/> .
-source		SELECT "Id", "Shortname", "Detail-en-Header", ST_AsText("Geometry") AS wkt, "SkiAreaMapURL", "SkiRegionId" FROM v_skiareasopen
+source		SELECT "Id", "Shortname", "Detail-en-Header", "SkiAreaMapURL", "SkiRegionId" FROM v_skiareasopen
 
 mappingId	SkiResort - geo
-target		data:geo/skiResort/{id} a schema:GeoCoordinates , geo:Geometry ; schema:latitude {latitude} ; schema:longitude {longitude} ; schema:elevation {AltitudeTo}; geo:asWKT {wkt}^^geo:wktLiteral . odh:ski-resorts/{id} schema:geo data:geo/skiResort/{id} ; geo:defaultGeometry data:geo/skiResort/{id} .
-source		SELECT "Id" AS id, "Latitude" AS latitude, "Longitude" AS longitude, "AltitudeTo" AS AltitudeTo, ST_AsText("Geometry") AS wkt
+target		data:geo/skiResort/{id} a schema:GeoCoordinates , geo:Geometry ; schema:latitude {latitude} ; schema:longitude {longitude} ; schema:elevation {AltitudeTo} . odh:ski-resorts/{id} schema:geo data:geo/skiResort/{id} ; geo:defaultGeometry data:geo/skiResort/{id} .
+source		SELECT "Id" AS id, "Latitude" AS latitude, "Longitude" AS longitude, "AltitudeTo" AS AltitudeTo
 			FROM "v_skiareasopen"
 
 mappingId	SkiRegion
 target		odh:ski-regions/{Id} a :SkiRegion ; rdfs:label {Shortname}^^xsd:string ; schema:name {Shortname}^^xsd:string  ; schema:elevation {Altitude}^^xsd:decimal .
-source		SELECT "Id", "Shortname", ST_AsText("Geometry") AS wkt, "Altitude" FROM v_skiregionsopen
+source		SELECT "Id", "Shortname", "Altitude" FROM v_skiregionsopen
 
 mappingId	SkiRegion - geo
-target		data:geo/skiRegion/{id} a schema:GeoCoordinates , geo:Geometry ; schema:latitude {latitude} ; schema:longitude {longitude} ; geo:asWKT {wkt}^^geo:wktLiteral . odh:ski-regions/{id} schema:geo data:geo/skiRegion/{id} ; geo:defaultGeometry data:geo/skiResort/{id} .
-source		SELECT "Id" AS id, "Latitude" AS latitude, "Longitude" AS longitude, "Altitude" AS altitude, ST_AsText("Geometry") AS wkt
+target		data:geo/skiRegion/{id} a schema:GeoCoordinates , geo:Geometry ; schema:latitude {latitude} ; schema:longitude {longitude} . odh:ski-regions/{id} schema:geo data:geo/skiRegion/{id} ; geo:defaultGeometry data:geo/skiResort/{id} .
+source		SELECT "Id" AS id, "Latitude" AS latitude, "Longitude" AS longitude, "Altitude" AS altitude
 			FROM "v_skiregionsopen"
 
 mappingId	SkiResort_Area
@@ -184,12 +151,12 @@ source		select "EventLocation"
 			from v_eventeuracnoi
 
 mappingId	Food establishments
-target		odh:food-establishments/{Id} a schema:FoodEstablishment ; schema:name {Detail-de-Title}@de , {Detail-it-Title}@it , {Detail-en-Title}@en ; schema:description {Detail-de-BaseText}@de , {Detail-it-BaseText}@it , {Detail-en-BaseText}@en ; schema:geo data:geo/gastronomy/{Id} ; geo:defaultGeometry data:geo/gastronomy/{Id} ; schema:address data:address/gastronomy/{Id} ; schema:telephone {ContactInfos-de-Phonenumber} ; schema:hasMenu data:menu/gastronomy/{Id} ; sioc:has_container <https://kg.opendatahub.bz.it/food-establishments/> .
+target		odh:food-establishments/{Id} a schema:FoodEstablishment ; schema:name {Detail-de-Title}@de , {Detail-it-Title}@it , {Detail-en-Title}@en ; schema:geo data:geo/gastronomy/{Id} ; geo:defaultGeometry data:geo/gastronomy/{Id} ; schema:address data:address/gastronomy/{Id} ; schema:telephone {ContactInfos-de-Phonenumber} ; schema:hasMenu data:menu/gastronomy/{Id} ; sioc:has_container <https://kg.opendatahub.bz.it/food-establishments/> .
 source		SELECT * FROM v_gastronomiesopen
 
 mappingId	Food establishments - geo
-target		data:geo/gastronomy/{Id} a schema:GeoCoordinates , geo:Geometry ; schema:latitude {Latitude} ; schema:elevation {Altitude} ; schema:longitude {Longitude} ; geo:asWKT {wkt}^^geo:wktLiteral .
-source		SELECT *, ST_AsText("Geometry") AS wkt FROM v_gastronomiesopen
+target		data:geo/gastronomy/{Id} a schema:GeoCoordinates , geo:Geometry ; schema:latitude {Latitude} ; schema:elevation {Altitude} ; schema:longitude {Longitude} .
+source		SELECT * FROM v_gastronomiesopen
 
 mappingId	Food establishments - address
 target		data:address/gastronomy/{Id} a schema:PostalAddress ; schema:streetAddress {ContactInfos-de-Address}@de , {ContactInfos-it-Address}@it , {ContactInfos-en-Address}@en ; schema:postalCode {ContactInfos-de-ZipCode} ; schema:addressLocality {ContactInfos-de-City}@de , {ContactInfos-it-City}@it , {ContactInfos-en-City}@en .
@@ -275,37 +242,13 @@ source		SELECT *
 			FROM "v_gastronomiesopen_CategoryCodes"
 			WHERE "Shortname" = 'Braugarten'
 
-mappingId	Asian cuisine
-target		odh:food-establishments/{Id} schema:servesCuisine "asian"@en , "asiatisch"@de , "asiatica"@it .
-source		SELECT "Id", "Detail-it-BaseText", "Detail-de-BaseText"
-			FROM "v_gastronomiesopen"
-			WHERE "Detail-it-BaseText" like '%asiat%' OR "Detail-de-BaseText" like '%asiat%'
-
-mappingId	Mediterranean cuisine
-target		odh:food-establishments/{Id} schema:servesCuisine "mediterranean"@en , "mediterrane"@de , "mediterranea"@it .
-source		SELECT "Id", "Detail-it-BaseText", "Detail-de-BaseText"
-			FROM "v_gastronomiesopen"
-			WHERE "Detail-it-BaseText" like '%mediterra%' OR "Detail-de-BaseText" like '%mediterra%'
-
-mappingId	Apfelstrudel
-target		data:menu/gastronomy/{Id} schema:hasMenuItem data:menuitem/apfelstrudel/{Id} . data:menuitem/apfelstrudel/{Id} schema:name "Apfelstrudel"@de , "strudel di mela"@it , "Apfelstrudel"@en .
-source		SELECT "Id"
-			FROM public.v_gastronomiesopen
-			WHERE "Detail-de-BaseText" ~ 'Apfelstrudel'
-
 mappingId	Lodging Business - aggregate rating
-target		data:rating/trustyou/{id}/{trustId} a schema:AggregateRating ; schema:author data:author/trustyou ; schema:bestRating "100"^^xsd:integer ; schema:ratingValue {score}^^xsd:integer ; schema:reviewCount {reviews}^^xsd:integer .
-source		select "Id" as id, "TrustYouID" as trustId, "TrustYouScore"/10 as  score , "TrustYouResults" as reviews from "v_accommodationsopen" where "TrustYouActive"=true and "TrustYouScore" > 0
+target		data:rating/trustyou/{id} a schema:AggregateRating ; schema:author data:author/trustyou ; schema:bestRating "100"^^xsd:integer ; schema:ratingValue {score}^^xsd:integer ; schema:reviewCount {reviews}^^xsd:integer .
+source		select "Id" as id, "TrustYouScore"/10 as  score , "TrustYouResults" as reviews from "v_accommodationsopen" where "TrustYouActive"=true and "TrustYouScore" > 0
 
 mappingId	Lodging Business -hasAggregateRating
-target		odh:lodging-businesses/{id} schema:aggregateRating data:rating/trustyou/{id}/{trustId} .
-source		select "Id" as id, "TrustYouID" as trustId from "v_accommodationsopen" where "TrustYouActive"=true and "TrustYouScore" > 0
-
-mappingId	Lodging Business - image
-target		odh:lodging-businesses/{id} schema:image <{image}> .
-source		select  "accommodationsopen_Id" as id , "ImageUrl" as image from "v_accommodationsopen_ImageGallery" where
-			( ("ValidTo" IS NULL OR "ValidTo" !~ '(?:(\d\d\d\d)-(0[1-9]|10|11|12)-([0-2]\d|30|31))T(([01]\d|2[0-3])(?:\:([0-5]\d)(?::([0-5]\d))))') OR (TO_TIMESTAMP("ValidTo", 'YYYY-MM-DDTHH24:MI:SS') > NOW()  ) )
-			AND (("ValidFrom" IS NULL OR "ValidFrom" !~ '(?:(\d\d\d\d)-(0[1-9]|10|11|12)-([0-2]\d|30|31))T(([01]\d|2[0-3])(?:\:([0-5]\d)(?::([0-5]\d))))') OR (TO_TIMESTAMP("ValidFrom", 'YYYY-MM-DDTHH24:MI:SS') < NOW()))
+target		odh:lodging-businesses/{id} schema:aggregateRating data:rating/trustyou/{id} .
+source		select "Id" as id from "v_accommodationsopen" where "TrustYouActive"=true and "TrustYouScore" > 0
 
 mappingId	MAPID-9dbd9116f9f84c78961099f0004a9690
 target		data:author/trustyou a schema:Organization ; schema:name "Trust you"^^xsd:string ; schema:url <https://www.trustyou.com/> .
@@ -318,10 +261,6 @@ source		select "Id" as id,  "AccoCategoryId" as rating, (CASE WHEN "AccoCategory
 mappingId	Price range
 target		odh:lodging-businesses/{id} schema:priceRange {value}^^xsd:string .
 source		select "Id" as id,  (CASE WHEN "AccoCategoryId" = '1flowers' or "AccoCategoryId" = '1stars'  or "AccoCategoryId" = '1suns' or "AccoCategoryId" = '2flowers' or "AccoCategoryId" = '2stars'  or "AccoCategoryId" = '2suns'   THEN '€'  WHEN "AccoCategoryId" = '3flowers' or "AccoCategoryId" = '3stars'  or "AccoCategoryId" = '3suns' or "AccoCategoryId" = '3sstars'  THEN '€€'  WHEN "AccoCategoryId" = '4flowers' or "AccoCategoryId" = '4stars'  or "AccoCategoryId" = '4suns'   THEN '€€€'  WHEN "AccoCategoryId" = '4sstars' or "AccoCategoryId" = '5flowers' or "AccoCategoryId" = '5stars'  or "AccoCategoryId" = '5suns' THEN '€€€€' ELSE NULL END ) as value FROM "v_accommodationsopen"
-
-mappingId	Lodging Business - image rank
-target		<{image}> :rankingValue {rankValue}^^xsd:integer .
-source		select  "ImageUrl" as image, "ListPosition" as rankValue  from "v_accommodationsopen_ImageGallery"
 
 mappingId	road_segment_geom
 target		data:road_segment/{id} geo:defaultGeometry data:road_segment/geometry/{id} . data:road_segment/geometry/{id} geo:asWKT {wkt}^^geo:wktLiteral .
@@ -1005,10 +944,6 @@ source		SELECT * FROM intimev2.station WHERE stationtype='ParkingStation'
 mappingId	metadata
 target		data:station/{station_id} :hasStationMetadata {json}^^xsd:string .
 source		SELECT * FROM intimev2.metadata
-
-mappingId	municipality_geom
-target		odh:municipalities/0{istat_code} geo:defaultGeometry odh:municipalities/geometry/0{istat_code} . odh:municipalities/geometry/0{istat_code} geo:asWKT {wkt}^^geo:wktLiteral .
-source		SELECT istat_code, ST_AsText(geom_4326) AS wkt FROM odp_municipalities
 
 mappingId	LodgingBusiness-municipality
 target		odh:lodging-businesses/{Id} schema:containedInPlace odh:municipalities/{IstatNumber} . 


### PR DESCRIPTION
This PR adapts the mapping to recent changes on the open tables on the tourism dataset.

It also includes some temporary removals due the absence of geometry columns generated a SQL script managed by Flyway, which has not been applied yet to the new database. Similar another removal is due to the temporary absence of the `odp_municipalities` table, introduced by Flyway as well.

It also updates the SQL script mentioned above as the geospatial coordinates of POIs are now in a different derived table.

The most important changes observed are the absence of open information about rooms and images for lodging businesses.

I was able to run Ontop successfully on my laptop while connecting to the new database.

Before deploying this PR in production, we will need to re-enable mapping entries related to geometries, as many SPARQL queries need them.
