### PR TITLE
Remove query on largest accommodation facilities

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -195,21 +195,6 @@
 					</div>
 					<div class="query">
 						<div class="query-contents">
-							<svg class="query-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 101 101">
-								<path d="M88.43,81.83,55.13,15.21a1.5,1.5,0,0,0-2.68,0L43.9,32.29,32,8.5a1.5,1.5,0,0,0-2.68,0L18.14,30.86v0L2.66,61.83A1.5,1.5,0,0,0,4,64H28L19.14,81.83A1.5,1.5,0,0,0,20.48,84H87.08a1.5,1.5,0,0,0,1.34-2.17ZM53.78,19.23l14.7,29.42c-5.95,2.4-9,.62-12.55-1.46C53.4,45.69,50.52,44,46.5,44a13.44,13.44,0,0,0-5.7,1.21ZM30.67,12.52,39,29.24c-3.29,1.3-4.83.37-6.76-.8a9.51,9.51,0,0,0-5.16-1.79,10.6,10.6,0,0,0-3.92.82ZM6.43,61,20.71,32.44c.75-.62,3.54-2.78,6.4-2.78A6.82,6.82,0,0,1,30.71,31c2.15,1.3,4.82,2.91,9.66.92l1.86,3.71L29.55,61ZM22.9,81l8.81-17.63a1.49,1.49,0,0,0,.2-.4l4.85-9.7a1.45,1.45,0,0,0,.11-.17A10.69,10.69,0,0,1,46.5,47c3.2,0,5.49,1.35,7.92,2.77,3.73,2.19,8,4.67,15.42,1.57L84.66,81Z"/>
-							</svg>
-							<div class="query-title">Tourism - Find the largest accommodation facilities</div>
-							<div class="query-text">Out of the many accommodation facilities in South Tyrol, some are larger, some are smaller. Do you know the largest ones?</div>
-							<a class="query-action" onclick='runQuery("Tourism", 2)'>
-								See it in action
-								<svg width="6" height="12" viewBox="0 0 6 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-									<path d="M3.75023 9.0075L3.75023 -9.83566e-08L2.25014 -1.63928e-07L2.25014 9.0075L-3.9373e-07 9.0075L3.00018 12L6.00037 9.0075L3.75023 9.0075Z" fill="black"/>
-								</svg>
-							</a>
-						</div>
-					</div>
-					<div class="query">
-						<div class="query-contents">
 							<svg class="query-icon" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 64 64" xml:space="preserve">
                     <path d="M53,42c-0.654,0-1.292,0.068-1.915,0.178l-0.529-1.94C51.349,40.087,52.164,40,53,40v-2c-1.018,0-2.012,0.104-2.973,0.298
                       L48,30.866V25c0.552,0,1-0.448,1-1v-1h3v-2h-3v-1c0-0.552-0.448-1-1-1h-7.819l0.806-4.835C40.996,14.11,41,14.055,41,14v-2.35
@@ -249,7 +234,7 @@
                   </svg>
 							<div class="query-title">Tourism - Highest mountain shelters</div>
 							<div class="query-text">You always wanted to visit one of the highest mountain shelters in South Tyrol and wondered where they are.</div>
-							<a class="query-action" onclick='runQuery("Tourism", 3)'>
+							<a class="query-action" onclick='runQuery("Tourism", 2)'>
 								See it in action
 								<svg width="6" height="12" viewBox="0 0 6 12" fill="none" xmlns="http://www.w3.org/2000/svg">
 									<path d="M3.75023 9.0075L3.75023 -9.83566e-08L2.25014 -1.63928e-07L2.25014 9.0075L-3.9373e-07 9.0075L3.00018 12L6.00037 9.0075L3.75023 9.0075Z" fill="black"/>

--- a/website/js/queries.js
+++ b/website/js/queries.js
@@ -15,13 +15,6 @@ const queryList = {
 			"output": "leaflet",
 		},
 		{
-			"query": "PREFIX geo: <http://www.opengis.net/ont/geosparql#>\nPREFIX schema: <http://schema.org/>\nPREFIX : <http://noi.example.org/ontology/odh#>\n \nSELECT ?pos\n    (SUM(?numberUnits) AS ?accommodationCount) #Sums all the accommodation units\n    (SUM(?maxPersons) AS ?countMaxPersons) #Sum the hosting capabilities\n    (CONCAT(?lbName, ': ', str(?accommodationCount), ' accommodations, max ', str(?countMaxPersons), ' guests') AS ?posLabel)\nWHERE {\n # LodgingBusiness\n ?lb a schema:LodgingBusiness ; \n    schema:name ?lbName ; \n    geo:defaultGeometry/geo:asWKT ?pos .\n \n # Accommodation\n ?a a schema:Accommodation ;\n    schema:containedInPlace ?lb ; \n    :numberOfUnits ?numberUnits ;\n    schema:occupancy/schema:maxValue ?maxOccupancyPerRoom .\n \n # Computation of maxPersons per accommodation\n BIND (?numberUnits * ?maxOccupancyPerRoom AS ?maxPersons)\n FILTER (lang(?lbName)='en')\n}\nGROUP BY ?lb ?lbName ?pos\nORDER BY DESC(?countMaxPersons)\nLIMIT 50\n"
-			,
-			"tabName": "Accommodation facilities",
-			"tabId": "fc",
-			"output": "leaflet",
-		},
-		{
 			"query": "PREFIX schema: <http://schema.org/>\nPREFIX geo: <http://www.opengis.net/ont/geosparql#>\nPREFIX : <http://noi.example.org/ontology/odh#>\n \nSELECT ?h ?pos (CONCAT(?hName, ' (', str(?altitude), ' m)') AS ?posLabel) ?altitude\nWHERE {\n  ?h a schema:LodgingBusiness ;\n      schema:name ?hName ;      \n      geo:defaultGeometry/geo:asWKT ?pos ;\n      schema:geo/schema:elevation ?altitude ;\n  FILTER (lang(?hName) = 'de')\n  FILTER (?altitude > 2500)\n  FILTER REGEX(?hName, \"hütte\", \"i\")\n}",
 			"tabName": "Mountain shelters",
 			"tabId": "mt",


### PR DESCRIPTION
Remove query Tourism - Find the largest accommodation facilities, since we don't have access to information about the rooms anymore (they are not open data anymore), so we cannot compute how large lodging businesses are.