### PR TITLE
Add Code of Conduct for Open Data Hub

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,14 @@
+<!--
+SPDX-FileCopyrightText: NOI Techpark
+SPDX-License-Identifier: CC0-1.0
+-->
+
+# Code of Conduct
+
+Hello everyone,
+
+We’re sharing the Code of Conduct for Open Data Hub to ensure a respectful, inclusive, and collaborative environment for all members. We kindly ask everyone to take a few minutes to carefully review the document linked below and familiarize themselves with the guidelines.
+
+By being part of this community, you agree to follow these principles and help maintain a positive space for everyone.
+
+https://cloud.opendatahub.com/index.php/s/BTiqmMyQM4q45TN


### PR DESCRIPTION
Added a Code of Conduct document to promote inclusivity and respect within the community.